### PR TITLE
Remove log-bin from pxc80 options

### DIFF
--- a/conf/mysql_options_pxc80.txt
+++ b/conf/mysql_options_pxc80.txt
@@ -858,7 +858,6 @@ local-infile=0
 lock-wait-timeout=31536000
 lock-wait-timeout=0
 lock-wait-timeout=2048
-log-bin
 log-bin-trust-function-creators=1
 log-bin-trust-function-creators=0
 log-bin-use-v1-row-events=1


### PR DESCRIPTION
It is enabled by default + fails execution with:
`Traceback (most recent call last):
  File "/dev/shm/qa/pxc-qa/suite/random_qa/random_mysqld_option_test.py", line 97, in <module>
    opt_value = mysql_option.split('=')[1]
IndexError: list index out of range
`