### PR TITLE
Fix tests to work with 9.6 server.

### DIFF
--- a/base_test.py
+++ b/base_test.py
@@ -1,4 +1,6 @@
 import argparse
+import json
+import os
 
 from config import WORKDIR, NODE, PT_BASEDIR, BASEDIR, SERVER, PXC_LOWER_BASE, PXC_UPPER_BASE
 from util import pxc_startup, ps_startup
@@ -7,6 +9,7 @@ from util.utility import *
 workdir = WORKDIR
 pt_basedir = PT_BASEDIR
 server = SERVER
+comp_name = 'component_keyring_file'
 
 # Read argument
 parser = argparse.ArgumentParser(prog='PXC test', usage='%(prog)s [options]')
@@ -16,9 +19,7 @@ parser.add_argument('-d', '--debug', action='store_true',
                     help='This option will enable debug logging')
 
 args = parser.parse_args()
-encryption = 'NO'
-if args.encryption_run is True:
-    encryption = 'YES'
+encryption = args.encryption_run
 
 debug = 'NO'
 if args.debug is True:
@@ -32,6 +33,16 @@ upper_version = get_mysql_version(PXC_UPPER_BASE)
 low_version_num = utility_cmd.version_check(PXC_LOWER_BASE)
 high_version_num = utility_cmd.version_check(PXC_UPPER_BASE)
 db = "test"
+
+if encryption:
+    if int(version) >= int("080024"):
+        with open(os.path.join(BASEDIR, 'bin', 'mysqld.my'), 'w') as manifest_file:
+            json.dump({"read_local_manifest": True}, manifest_file, indent=2)
+            manifest_file.write('\n')
+
+        with open(os.path.join(BASEDIR, 'lib', 'plugin', comp_name + '.cnf'), 'w') as cnf_file:
+            json.dump({"read_local_config": True}, cnf_file, indent=2)
+            cnf_file.write('\n')
 
 
 class BaseTest:
@@ -64,10 +75,10 @@ class BaseTest:
         else:
             my_extra_options = self.__my_extra
 
-        # Start PXC cluster for ChaosMonkey test
+        # Start PXC cluster
         server_startup = pxc_startup.StartCluster(self.__number_of_nodes, debug, self.__version)
         server_startup.sanity_check()
-        if encryption == 'YES' or self.encrypt:
+        if encryption or self.encrypt:
             server_startup.create_config('encryption', self.__wsrep_provider_options,
                                          custom_conf_settings=custom_conf_settings)
         elif self.ssl:
@@ -76,7 +87,7 @@ class BaseTest:
         else:
             server_startup.create_config('none', self.__wsrep_provider_options,
                                          custom_conf_settings=custom_conf_settings)
-        server_startup.initialize_cluster()
+        server_startup.initialize_cluster(encryption=encryption or self.encrypt)
         if self.__extra_config_file is not None:
             server_startup.add_myextra_configuration(self.__extra_config_file)
         self.pxc_nodes = server_startup.start_cluster(my_extra_options, terminate_on_startup_failure)
@@ -106,11 +117,11 @@ class BaseTest:
             my_extra_options = self.__my_extra
         server_startup = ps_startup.StartPerconaServer(self.__number_of_nodes, debug, self.__version)
         server_startup.test_sanity_check()
-        if encryption == 'YES':
+        if encryption or self.encrypt:
             server_startup.create_config('encryption')
         else:
             server_startup.create_config()
-        server_startup.initialize_server()
+        server_startup.initialize_server(encryption=encryption or self.encrypt)
         if self.__extra_config_file is not None:
             server_startup.add_myextra_configuration(self.__extra_config_file)
         self.ps_nodes = server_startup.start_server(my_extra_options)

--- a/conf/encryption.cnf
+++ b/conf/encryption.cnf
@@ -5,5 +5,3 @@ default_table_encryption = ON
 innodb_redo_log_encrypt = ON
 innodb_undo_log_encrypt = ON
 innodb_temp_tablespace_encrypt = ON
-early-plugin-load = keyring_file.so
-keyring_file_data = keyring

--- a/suite/correctness/chaosmonkey-test.py
+++ b/suite/correctness/chaosmonkey-test.py
@@ -24,7 +24,7 @@ class ChaosMonkeyQA(BaseTest):
 
         sysbench.test_sanity_check(db)
         sysbench.test_sysbench_load(db)
-        if encryption == 'YES':
+        if encryption:
             sysbench.encrypt_sysbench_tables(db)
         sysbench.test_sysbench_oltp_read_write(db, background=True)
 

--- a/suite/correctness/cluster_interaction.py
+++ b/suite/correctness/cluster_interaction.py
@@ -28,7 +28,7 @@ class ClusterInteraction(BaseTest):
         sysbench = sysbench_run.SysbenchRun(self.node1, debug)
         sysbench.test_sanity_check(db)
         sysbench.test_sysbench_load(db, SYSBENCH_TABLE_COUNT, SYSBENCH_THREADS, SYSBENCH_NORMAL_TABLE_SIZE)
-        if encryption == 'YES':
+        if encryption:
             sysbench.encrypt_sysbench_tables(db)
         if background_run:
             sysbench.test_sysbench_oltp_read_write(db, SYSBENCH_TABLE_COUNT, SYSBENCH_TABLE_COUNT,

--- a/suite/correctness/consistency_check.py
+++ b/suite/correctness/consistency_check.py
@@ -25,7 +25,7 @@ class ConsistencyCheck(BaseTest):
 
         sysbench.test_sanity_check(db)
         sysbench.test_sysbench_load(db, SYSBENCH_TABLE_COUNT, SYSBENCH_THREADS, SYSBENCH_NORMAL_TABLE_SIZE)
-        if encryption == 'YES':
+        if encryption:
             sysbench.encrypt_sysbench_tables(db)
 
     def data_load(self, load_db):

--- a/suite/correctness/crash_recovery.py
+++ b/suite/correctness/crash_recovery.py
@@ -31,7 +31,7 @@ class CrashRecovery(BaseTest):
 
         sysbench.test_sanity_check(db)
         sysbench.test_sysbench_load(db, SYSBENCH_TABLE_COUNT, SYSBENCH_THREADS, SYSBENCH_NORMAL_TABLE_SIZE)
-        if encryption == 'YES':
+        if encryption:
             sysbench.encrypt_sysbench_tables(db)
         sysbench.test_sysbench_oltp_read_write(db, SYSBENCH_TABLE_COUNT, SYSBENCH_THREADS,
                                                    SYSBENCH_NORMAL_TABLE_SIZE, SYSBENCH_RUN_TIME, True)

--- a/suite/galera_sr/galera_basic_sr_qa.py
+++ b/suite/galera_sr/galera_basic_sr_qa.py
@@ -15,7 +15,12 @@ from util import table_checksum
 
 class StreamingReplication(BaseTest):
     def __init__(self):
-        super().__init__(my_extra="--innodb_buffer_pool_size=2G --innodb_log_file_size=1G")
+        my_extra = "--innodb_buffer_pool_size=2G"
+        if int(version) < int("090000"):
+            my_extra = my_extra + " --innodb_log_file_size=1G"
+        else:
+            my_extra = my_extra + " --innodb_redo_log_capacity=2G"
+        super().__init__(my_extra=my_extra)
 
     def sysbench_run(self):
         # Sysbench data load

--- a/suite/galera_sr/thread_pool_qa.py
+++ b/suite/galera_sr/thread_pool_qa.py
@@ -16,7 +16,12 @@ from util import pxc_startup
 
 class ThreadPooling(BaseTest):
     def __init__(self):
-        super().__init__(my_extra="--max-connections=1500 --innodb_buffer_pool_size=2G --innodb_log_file_size=1G")
+        my_extra = "--max-connections=1500 --innodb_buffer_pool_size=2G"
+        if int(version) < int("090000"):
+            my_extra = my_extra + " --innodb_log_file_size=1G"
+        else:
+            my_extra = my_extra + " --innodb_redo_log_capacity=2G"
+        super().__init__(my_extra=my_extra)
 
     def sysbench_run(self, port):
         # Sysbench data load
@@ -41,7 +46,7 @@ class ThreadPooling(BaseTest):
                 itertools.product(thread_handling_option, thread_pool_size, thread_pool_max_threads):
             my_extra = "--thread_handling=" + tp_option + " --thread_pool_size=" + str(tp_size) + \
                        " --thread_pool_max_threads=" + str(tp_max_thread)
-            # Start PXC cluster for encryption test
+            # Start PXC cluster for thread pooling test
             utility_cmd.check_testcase(0, "Thread pooling options : " + my_extra)
             server_startup = pxc_startup.StartCluster(3, debug)
             server_startup.sanity_check()

--- a/suite/loadtest/sysbench_load_test.py
+++ b/suite/loadtest/sysbench_load_test.py
@@ -16,7 +16,12 @@ from util import table_checksum
 
 class SysbenchLoadTest(BaseTest):
     def __init__(self, number_of_nodes: int = None):
-        super().__init__(my_extra="--max-connections=1500 --innodb_buffer_pool_size=2G --innodb_log_file_size=1G")
+        my_extra = "--max-connections=1500 --innodb_buffer_pool_size=2G"
+        if int(version) < int("090000"):
+            my_extra = my_extra + " --innodb_log_file_size=1G"
+        else:
+            my_extra = my_extra + " --innodb_redo_log_capacity=2G"
+        super().__init__(my_extra=my_extra)
 
     def sysbench_run(self, nodes: list[DbConnection]):
         # Sysbench load test

--- a/suite/loadtest/sysbench_random_load_test.py
+++ b/suite/loadtest/sysbench_random_load_test.py
@@ -14,7 +14,12 @@ from util import table_checksum
 
 class SysbenchRandomLoadTest(BaseTest):
     def __init__(self):
-        super().__init__(my_extra="--max-connections=1500 --innodb_buffer_pool_size=2G --innodb_log_file_size=1G")
+        my_extra = "--max-connections=1500 --innodb_buffer_pool_size=2G"
+        if int(version) < int("090000"):
+            my_extra = my_extra + " --innodb_log_file_size=1G"
+        else:
+            my_extra = my_extra + " --innodb_redo_log_capacity=2G"
+        super().__init__(my_extra=my_extra)
 
     def sysbench_run(self, nodes: list[DbConnection]):
         checksum = ""

--- a/suite/loadtest/sysbench_wsrep_provider_option_random_test.py
+++ b/suite/loadtest/sysbench_wsrep_provider_option_random_test.py
@@ -13,7 +13,12 @@ from util import utility
 
 class WSREPProviderRandomTest(BaseTest):
     def __init__(self):
-        super().__init__(my_extra="--max-connections=1500 --innodb_buffer_pool_size=2G --innodb_log_file_size=1G")
+        my_extra = "--max-connections=1500 --innodb_buffer_pool_size=2G"
+        if int(version) < int("090000"):
+            my_extra = my_extra + " --innodb_log_file_size=1G"
+        else:
+            my_extra = my_extra + " --innodb_redo_log_capacity=2G"
+        super().__init__(my_extra=my_extra)
 
     def start_random_test(self):
         wsrep_provider_options = {

--- a/suite/replication/backup_replication.py
+++ b/suite/replication/backup_replication.py
@@ -36,7 +36,7 @@ class SetupReplication(BaseTest):
 
         sysbench.test_sanity_check(test_db)
         sysbench.test_sysbench_load(test_db, SYSBENCH_TABLE_COUNT, SYSBENCH_THREADS, SYSBENCH_NORMAL_TABLE_SIZE)
-        if encryption == 'YES':
+        if encryption:
             for i in range(1, int(SYSBENCH_TABLE_COUNT) + 1):
                 self.node1.execute('alter table ' + test_db + '.sbtest' + str(i) + " encryption='Y'")
 

--- a/suite/replication/replication.py
+++ b/suite/replication/replication.py
@@ -30,7 +30,7 @@ class SetupReplication(BaseTest):
 
         sysbench.test_sanity_check(test_db)
         sysbench.test_sysbench_load(test_db, SYSBENCH_TABLE_COUNT, SYSBENCH_THREADS, SYSBENCH_NORMAL_TABLE_SIZE)
-        if encryption == 'YES':
+        if encryption:
             for i in range(1, int(SYSBENCH_TABLE_COUNT) + 1):
                 node.execute('alter table ' + test_db + '.sbtest' + str(i) + " encryption='Y'")
 

--- a/suite/ssl/encryption_qa.py
+++ b/suite/ssl/encryption_qa.py
@@ -49,20 +49,18 @@ class EncryptionTest(BaseTest):
                        "innodb_redo_log_encrypt": val4,
                        "innodb_undo_log_encrypt": val5,
                        "binlog_encryption": val6,
-                       "early-plugin-load": "keyring_file.so",
-                       "keyring_file_data": "keyring",
                        "encrypt_tmp_files": "ON"}
 
-            server_startup.create_config('encryption', custom_conf_settings=options,
+            server_startup.create_config(wsrep_extra='encryption', custom_conf_settings=options,
                                          default_encryption_conf=False)
 
             if options['innodb_sys_tablespace_encrypt'] == 'ON':
                 init_extra = ("--innodb_sys_tablespace_encrypt=ON --early-plugin-load=keyring_file.so "
                               "--keyring_file_data=keyring")
-                server_startup.initialize_cluster(init_extra)
+                server_startup.initialize_cluster(encryption=True, init_extra=init_extra)
 
             else:
-                server_startup.initialize_cluster()
+                server_startup.initialize_cluster(encryption=True)
             self.pxc_nodes = server_startup.start_cluster()
             self.node1 = self.pxc_nodes[0]
             self.node2 = self.pxc_nodes[1]

--- a/suite/ssl/ssl_qa.py
+++ b/suite/ssl/ssl_qa.py
@@ -23,7 +23,7 @@ class SSLCheck(BaseTest):
 
         sysbench.test_sanity_check(test_db)
         sysbench.test_sysbench_load(test_db, SYSBENCH_TABLE_COUNT, SYSBENCH_THREADS, SYSBENCH_NORMAL_TABLE_SIZE)
-        if encryption == 'YES':
+        if encryption:
             for i in range(1, int(SYSBENCH_THREADS) + 1):
                 self.node1.execute(' alter table ' + test_db + '.sbtest' + str(i) + " encryption='Y'")
 

--- a/suite/sysbench_run/sysbench_customized_dataload_test.py
+++ b/suite/sysbench_run/sysbench_customized_dataload_test.py
@@ -13,7 +13,12 @@ from util import table_checksum
 
 class SysbenchLoadTest(BaseTest):
     def __init__(self):
-        super().__init__(my_extra="--max-connections=1500 --innodb_buffer_pool_size=8G --innodb_log_file_size=1G")
+        my_extra = "--max-connections=1500 --innodb_buffer_pool_size=8G"
+        if int(version) < int("090000"):
+            my_extra = my_extra + " --innodb_log_file_size=1G"
+        else:
+            my_extra = my_extra + " --innodb_redo_log_capacity=2G"
+        super().__init__(my_extra=my_extra)
 
     def sysbench_run(self, node: DbConnection):
         # Sysbench load test

--- a/suite/sysbench_run/sysbench_oltp_test.py
+++ b/suite/sysbench_run/sysbench_oltp_test.py
@@ -13,7 +13,12 @@ from util import table_checksum
 
 class SysbenchOLTPTest(BaseTest):
     def __init__(self):
-        super().__init__(my_extra="--max-connections=1500 --innodb_buffer_pool_size=8G --innodb_log_file_size=1G")
+        my_extra = "--max-connections=1500 --innodb_buffer_pool_size=8G"
+        if int(version) < int("090000"):
+            my_extra = my_extra + " --innodb_log_file_size=1G"
+        else:
+            my_extra = my_extra + " --innodb_redo_log_capacity=2G"
+        super().__init__(my_extra=my_extra)
 
     def sysbench_run(self, nodes: list[DbConnection]):
         # Sysbench OLTP Test

--- a/suite/sysbench_run/sysbench_read_only_test.py
+++ b/suite/sysbench_run/sysbench_read_only_test.py
@@ -13,7 +13,12 @@ from util import table_checksum
 
 class SysbenchReadOnlyTest(BaseTest):
     def __init__(self):
-        super().__init__(my_extra="--max-connections=1500 --innodb_buffer_pool_size=8G --innodb_log_file_size=1G")
+        my_extra = "--max-connections=1500 --innodb_buffer_pool_size=8G"
+        if int(version) < int("090000"):
+            my_extra = my_extra + " --innodb_log_file_size=1G"
+        else:
+            my_extra = my_extra + " --innodb_redo_log_capacity=2G"
+        super().__init__(my_extra=my_extra)
 
     def sysbench_run(self, nodes: list[DbConnection]):
         # Sysbench load test

--- a/suite/upgrade/pxc_replication_upgrade.py
+++ b/suite/upgrade/pxc_replication_upgrade.py
@@ -30,7 +30,7 @@ class PXCUpgrade(BaseTest):
         sysbench_ps_node1.test_sanity_check(db)
         sysbench_ps_node1.test_sysbench_load(db, SYSBENCH_TABLE_COUNT, SYSBENCH_THREADS, SYSBENCH_NORMAL_TABLE_SIZE)
         if int(low_version_num) > int("050700"):
-            if encryption == 'YES':
+            if encryption:
                 for i in range(1, int(SYSBENCH_TABLE_COUNT) + 1):
                     self.ps_nodes[0].execute('alter table ' + db + '.sbtest' + str(i) + " encryption='Y'")
         sysbench_node1 = sysbench_run.SysbenchRun(self.node1, debug)

--- a/suite/upgrade/pxc_upgrade.py
+++ b/suite/upgrade/pxc_upgrade.py
@@ -27,7 +27,7 @@ class PXCUpgrade(BaseTest):
         sysbench_node1.test_sanity_check(db)
         sysbench_node1.test_sysbench_load(db, SYSBENCH_TABLE_COUNT, SYSBENCH_THREADS, SYSBENCH_NORMAL_TABLE_SIZE)
         if int(low_version_num) > int("050700"):
-            if encryption == 'YES':
+            if encryption:
                 for i in range(1, int(SYSBENCH_TABLE_COUNT) + 1):
                     self.node1.execute('alter table ' + db + '.sbtest' + str(i) + " encryption='Y'")
 

--- a/util/db_connection.py
+++ b/util/db_connection.py
@@ -236,6 +236,9 @@ class DbConnection:
     def get_port(self):
         return self.execute_get_value("select @@port")
 
+    def get_mysql_version(self):
+        return self.execute_get_value("select @@version")
+
     def get_user(self):
         return self.__user
 

--- a/util/ps_startup.py
+++ b/util/ps_startup.py
@@ -3,6 +3,7 @@
 # Updated by Parveez Baig
 # This will help us to start Percona Server
 
+import json
 import os
 import subprocess
 import random
@@ -15,6 +16,7 @@ from util.utility import Version, Utility
 workdir = WORKDIR
 base_dir = BASEDIR
 user = USER
+comp_name = 'component_keyring_file'
 
 cwd = os.path.dirname(os.path.realpath(__file__))
 parent_dir = os.path.normpath(os.path.join(cwd, '../'))
@@ -46,6 +48,12 @@ def node_socket(i: int):
 
 def init_log(i: int):
     return workdir + '/log/ps_init' + str(i) + '.log'
+
+
+def component_keyring_file_path(node_number: int):
+    keyring_dir = os.path.join(workdir, 'keyring')
+    os.makedirs(keyring_dir, exist_ok=True)
+    return os.path.join(keyring_dir, 'psnode' + str(node_number) + '_' + comp_name)
 
 
 def set_base_dir(server_version : Version):
@@ -128,6 +136,10 @@ class StartPerconaServer:
             cnf_name.write('!include ' + workdir_custom_conf + '\n')
             if conf_extra == 'encryption':
                 shutil.copy(default_encryption_conf, workdir_encryption_conf)
+                if int(version) < int("080024"):
+                    with open(workdir_encryption_conf, 'a+') as cnf_file:
+                        cnf_file.write('early-plugin-load = keyring_file.so\n')
+                        cnf_file.write('keyring_file_data = keyring\n')
                 cnf_name.write('!include ' + workdir_encryption_conf + '\n')
             cnf_name.close()
 
@@ -151,7 +163,7 @@ class StartPerconaServer:
         utility_cmd = utility.Utility(self.__debug)
         utility_cmd.check_testcase(result, "PS: Adding custom configuration")
 
-    def initialize_server(self):
+    def initialize_server(self, encryption: bool = False):
         """ Method to initialize the server database
             directories. This will initialize the server
             using --initialize-insecure option for
@@ -180,6 +192,16 @@ class StartPerconaServer:
                 print(initialize_node)
             run_query = subprocess.call(initialize_node, shell=True, stderr=subprocess.DEVNULL)
             result = ("{}".format(run_query))
+            if encryption:
+                if int(version) >= int("080024"):
+                    with open(os.path.join(datadir, 'mysqld.my'), 'w') as manifest_file:
+                        json.dump({"components": "file://" + comp_name}, manifest_file, indent=2)
+                        manifest_file.write('\n')
+
+                    with open(os.path.join(datadir, comp_name + '.cnf'), 'w') as cnf_file:
+                        json.dump({"path": component_keyring_file_path(i), "read_only": False}, cnf_file, indent=2)
+                        cnf_file.write('\n')
+
         utility_cmd = utility.Utility(self.__debug)
         utility_cmd.check_testcase(int(result), "PS: Initializing PS server")
 

--- a/util/pxc_startup.py
+++ b/util/pxc_startup.py
@@ -3,6 +3,7 @@
 # Updated by Parveez Baig
 # This will help us to start Percona XtraDB Cluster, Upgrade cluster nodes, Backup the cluster nodes.
 
+import json
 import os
 import subprocess
 import random
@@ -19,6 +20,7 @@ from util.utility import Version, Utility
 workdir = WORKDIR
 base_dir = BASEDIR
 user = USER
+comp_name = 'component_keyring_file'
 
 higher_version_basedir = PXC_UPPER_BASE
 lower_base_dir = PXC_LOWER_BASE
@@ -66,6 +68,12 @@ def node_startup_script(node_number: int):
 
 def init_log(node_number: int):
     return workdir + '/log/init' + str(node_number) + '.log'
+
+
+def component_keyring_file_path(node_number: int):
+    keyring_dir = os.path.join(workdir, 'keyring')
+    os.makedirs(keyring_dir, exist_ok=True)
+    return os.path.join(keyring_dir, 'node' + str(node_number) + '_' + comp_name)
 
 
 def add_conf(option_values: dict):
@@ -135,6 +143,10 @@ class StartCluster:
             shutil.copy(default_custom_cnf, workdir_custom_cnf)
         if wsrep_extra == 'encryption' and default_encryption_conf:
             shutil.copy(encryption_cnf, workdir_encryption_cnf)
+            if int(version) < int("080024"):
+                with open(workdir_encryption_cnf, 'a+') as cnf_file:
+                    cnf_file.write('early-plugin-load = keyring_file.so\n')
+                    cnf_file.write('keyring_file_data = keyring\n')
         for i in range(1, self.__number_of_nodes + 1):
             cnf = node_conf(i)
             shutil.copy(default_pxc_cnf, cnf)
@@ -195,7 +207,7 @@ class StartCluster:
         utility_cmd = utility.Utility(self.__debug)
         utility_cmd.check_testcase(result, "PXC: Adding custom configuration")
 
-    def initialize_cluster(self, init_extra=None):
+    def initialize_cluster(self, init_extra=None, encryption=False):
         """ Method to initialize the cluster database
             directories. This will initialize the cluster
             using --initialize-insecure option for
@@ -229,6 +241,16 @@ class StartCluster:
                 print(initialize_node)
             run_query = subprocess.call(initialize_node, shell=True, stderr=subprocess.DEVNULL)
             result = ("{}".format(run_query))
+            if encryption:
+                if int(version) >= int("080024"):
+                    with open(os.path.join(datadir, 'mysqld.my'), 'w') as manifest_file:
+                        json.dump({"components": "file://" + comp_name}, manifest_file, indent=2)
+                        manifest_file.write('\n')
+
+                    with open(os.path.join(datadir, comp_name + '.cnf'), 'w') as cnf_file:
+                        json.dump({"path": component_keyring_file_path(i), "read_only": False}, cnf_file, indent=2)
+                        cnf_file.write('\n')
+
         utility_cmd = utility.Utility(self.__debug)
         utility_cmd.check_testcase(int(result), "Initializing cluster")
 
@@ -424,16 +446,20 @@ class StartCluster:
         node.execute_queries(queries)
 
     @staticmethod
-    def pxb_backup(node: DbConnection, encryption: str, copy_back_to_ps_node: bool = False, debug: str = 'NO'):
+    def pxb_backup(node: DbConnection, encryption: bool, copy_back_to_ps_node: bool = False, debug: str = 'NO'):
         """ This method will backup PXC/PS data directory
             with the help of xtrabackup.
         """
         # Enable keyring file plugin if it is encryption run
-        if encryption == 'YES':
-            backup_extra = " --keyring-file-data=" + node.get_data_dir() + \
+        backup_extra = ''
+        if encryption:
+            version_info = node.get_mysql_version()
+            version = "{:02d}{:02d}{:02d}".format(int(version_info.split('.')[0]),
+                                                  int(version_info.split('.')[1]),
+                                                  int(version_info.split('.')[2]))
+            if int(version) < int("080024"):
+                backup_extra = " --keyring-file-data=" + node.get_data_dir() + \
                            "/keyring --early-plugin-load='keyring_file=keyring_file.so'"
-        else:
-            backup_extra = ''
 
         # Backup data using xtrabackup
         backup_cmd = ("xtrabackup --user=xbuser --password='test' --backup --target-dir=" + backup_dir +
@@ -462,8 +488,15 @@ class StartCluster:
             os.system(copy_backup)
 
             # Copy keyring file to destination directory for encryption startup
-            if encryption == 'YES':
-                os.system("cp " + node.get_data_dir() + "/keyring " + dest_datadir)
+            if encryption:
+                if int(version) >= int("080024"):
+                    dest_keyring_file = os.path.join(workdir, 'keyring', 'psnode1_' + comp_name)
+                    shutil.copy(component_keyring_file_path(node.get_node_number()), dest_keyring_file)
+                    with open(os.path.join(dest_datadir, comp_name + '.cnf'), 'w') as cnf_file:
+                        json.dump({"path": dest_keyring_file, "read_only": False}, cnf_file, indent=2)
+                        cnf_file.write('\n')
+                else:
+                    os.system("cp " + node.get_data_dir() + "/keyring " + dest_datadir)
 
         if debug == 'YES':
             print("Backup dir path: ", backup_dir)

--- a/util/pxc_util.py
+++ b/util/pxc_util.py
@@ -24,9 +24,9 @@ parser.add_argument('-d', '--debug', action='store_true',
                     help='This option will enable debug logging')
 args = parser.parse_args()
 if args.encryption_run is True:
-    encryption = 'YES'
+    encryption = True
 else:
-    encryption = 'NO'
+    encryption = False
 if args.debug is True:
     debug = 'YES'
 else:


### PR DESCRIPTION
Modified tests to use component_keyring_file instead of keyring_file plugin. Modified tests to use innodb_redo_log_capacity instead of innodb_log_file_size.

Tested locally. Tests works fine with encryption enabled.