### PR TITLE
Add option to run the tests in parallel.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,35 +1,50 @@
 PQA Framework
 ==============================================================================
 
-This suite will help us to test Percona XtraDB Cluster/Percona Server with various testcases. 
-You can customize the testcases 
-using configuration files without disturbing main code.
+PQA Framework is a Python-based test runner for Percona XtraDB Cluster (PXC)
+and Percona Server (PS). It runs tests from the `suite/` directory,
+and stores logs and failed-test artifacts under the
+configured work directory.
 
-Configuration details
+Use this project when you want to run one test, selected tests, selected suites,
+or suite tests.
+
+Prerequisites
 ------------------------------------------------------------------------------
 
-Basic configuration details are available in [config.ini](./config.ini) file. You need to change the configurations as 
-per your environment.
+Before running the framework, make sure the test host has:
 
-config.ini
-```
+- Python 3.
+- `mysql.connector` available to Python.
+- A PXC or PS binary tarball extracted on disk.
+- `sysbench` installed if running sysbench suites.
+- Percona Toolkit configured if running checksum-based tests.
+- `pstress` and its grammar file configured if running random QA pstress tests.
+
+The configured MySQL user is usually `root`, and the test servers are started
+with local sockets inside the framework work directory.
+
+Configuration
+------------------------------------------------------------------------------
+
+The main configuration file is [config.ini](./config.ini). Update it before the
+first run so all paths match your local environment.
+
+```ini
 [config]
 workdir = /dev/shm/qa
 basedir = /dev/shm/qa/PXC_tarball
-server=pxc
+server = pxc
 node = 3
 user = root
-ps1_socket = /tmp/psnode1.sock
-ps2_socket = /tmp/psnode2.sock
-ps3_socket = /tmp/psnode3.sock
 pt_basedir = /dev/shm/qa/percona-toolkit-3.0.10
 pstress_bin = /dev/shm/qa/pstress/src/pstress-pxc
 pstress_grammar_file = /dev/shm/qa/pstress/src/grammar.sql
 
 [sysbench]
-sysbench_user=sysbench
-sysbench_pass=sysbench
-sysbench_db=sbtest
+sysbench_user = sysbench
+sysbench_pass = sysbench
+sysbench_db = sbtest
 sysbench_table_count = 10
 sysbench_threads = 10
 sysbench_normal_table_size = 1000
@@ -41,33 +56,167 @@ sysbench_oltp_test_table_size = 10000000
 sysbench_read_qa_table_size = 100000
 sysbench_customized_dataload_table_size = 1000
 
-
 [upgrade]
-pxc_lower_base = /dev/shm/qa/Percona-XtraDB-Cluster-5.6.44-rel86.0-28.34-debug..Linux.x86_64
-pxc_upper_base = /dev/shm/qa/Percona-XtraDB-Cluster-5.7.25-rel28-31.35.1.Linux.x86_64.ssl100
+pxc_lower_base = /path/to/lower/version/tarball
+pxc_upper_base = /path/to/upper/version/tarball
 ```
 
-If you need to start Percona XtraDB Cluster/Percona Server with custom configuration you should add the parameters 
-in [custom.cnf](./conf/custom.cnf)
+Important settings:
 
-Initializing framework
---------------------------------------------
+- `workdir`: Temporary runtime directory. The framework removes and recreates
+  this path at the start of a run.
+- `basedir`: Extracted PXC or PS base directory. It must contain `bin/mysqld`.
+- `server`: Product to run in tests that support both products. Common values
+  are `pxc` and `ps`.
+- `node`: Number of nodes to start for cluster/server tests.
+- `pt_basedir`: Percona Toolkit base directory.
+- `pstress_bin` and `pstress_grammar_file`: Required for pstress tests.
+- `pxc_lower_base` and `pxc_upper_base`: Required for upgrade tests.
 
-`python3 qa_framework.py --testname=suite/replication/replication.py`
+Custom Server Configuration
+------------------------------------------------------------------------------
 
-Script usage info
-```$ python3 qa_framework.py  --help
-usage: QA Framework [options]
+Default server configuration files are in [conf/](./conf):
 
-optional arguments:
-  -h, --help            show this help message and exit
-  -t TESTNAME, --testname TESTNAME
-                        Specify test file location
-  -p {pxc,ps}, --product {pxc,ps}
-                        Specify product(PXC/PS) name to test
-  -s [{sysbench_run,loadtest,replication,correctness,ssl,upgrade,random_qa,galera_sr} [{sysbench_run,loadtest,replication,correctness,ssl,upgrade,random_qa,galera_sr} ...]], --suite [{sysbench_run,loadtest,replication,correctness,ssl,upgrade,random_qa,galera_sr} [{sysbench_run,loadtest,replication,correctness,ssl,upgrade,random_qa,galera_sr} ...]]
-                        Specify suite name
-  -e, --encryption-run  This option will enable encryption options
-  -d, --debug           This option will enable debug logging
+- [conf/pxc.cnf](./conf/pxc.cnf) for PXC nodes.
+- [conf/ps.cnf](./conf/ps.cnf) for PS nodes.
+- [conf/encryption.cnf](./conf/encryption.cnf) for encryption runs.
+- [conf/custom.cnf](./conf/custom.cnf) for local custom options.
 
+Add custom MySQL options to `conf/custom.cnf` when you want every generated
+server config to include them.
+
+Running Tests
+------------------------------------------------------------------------------
+
+Show available runner options:
+
+```bash
+python3 qa_framework.py --help
 ```
+
+Run a single test by filename. The framework searches all known suites:
+
+```bash
+python3 qa_framework.py --tests=replication.py
+```
+
+Run a single test with an explicit suite name:
+
+```bash
+python3 qa_framework.py --tests=replication.replication.py
+```
+
+Run multiple tests:
+
+```bash
+python3 qa_framework.py --tests=replication.py,gtid_replication.py
+```
+
+Run all tests from one suite:
+
+```bash
+python3 qa_framework.py --suites=replication
+```
+
+Run all tests from multiple suites:
+
+```bash
+python3 qa_framework.py --suites=replication,ssl
+```
+
+Run with encryption enabled:
+
+```bash
+python3 qa_framework.py --tests=ssl.encryption_qa.py --encryption-run
+```
+
+Run with debug logging enabled:
+
+```bash
+python3 qa_framework.py --tests=replication.py --debug
+```
+
+Run suite tests in parallel workers:
+
+```bash
+python3 qa_framework.py --suites=replication --number-of-workers=3
+```
+
+Available Suites
+------------------------------------------------------------------------------
+
+The framework currently recognizes these suite names:
+
+- `sysbench_run`
+- `loadtest`
+- `replication`
+- `correctness`
+- `ssl`
+- `upgrade`
+- `random_qa`
+- `galera_sr`
+
+Test and Log Output
+------------------------------------------------------------------------------
+
+The framework writes a high-level result file in the repository root, and copies
+it to `workdir` once the run completes:
+
+```text
+test_run_results.out
+<workdir>/test_run_results.out
+```
+
+Runtime logs are written under `workdir`:
+
+```text
+<workdir>/log/
+<workdir>/log/tests_log/
+<workdir>/failed_logs/
+```
+
+When `--number-of-workers` is used, each worker gets its own directory:
+
+```text
+<workdir>/w1/
+<workdir>/w2/
+<workdir>/w3/
+```
+
+Failed tests package logs into `<workdir>/failed_logs/` or the worker-specific
+`failed_logs/` directory.
+
+Disabling Tests
+------------------------------------------------------------------------------
+
+Tests can be skipped even when explicitly requested via `-t`/`-s` by listing
+them in a `disabled.list` file in the script working directory (alongside
+`qa_framework.py`):
+
+```text
+# Lines starting with '#' are comments and ignored
+consistency_check.py
+correctness.chaosmonkey-test.py
+```
+
+Rules:
+
+- Only entries ending in `.py` are treated as test names; blank lines and
+  comments (`#`) are ignored.
+- A plain filename (e.g. `consistency_check.py`) skips that test in **every**
+  suite it would otherwise run in.
+- A suite-qualified name (e.g. `correctness.chaosmonkey-test.py`) skips the test
+  **only** within that suite; a same-named test in another suite still runs.
+- Skipped tests are reported on stdout and in `test_run_results.out`.
+- If `disabled.list` does not exist, no tests are skipped.
+
+Notes:
+------------------------------------------------------------------------------
+
+- Run the framework from the repository root so `config.ini` is found.
+- Make sure `workdir` is safe to delete before running; it is recreated each run.
+- Use explicit suite-qualified test names when two suites may contain tests with
+  the same filename.
+- If no test is passed and no suite test is found, the runner exits without
+  starting any server.

--- a/base_test.py
+++ b/base_test.py
@@ -1,6 +1,9 @@
 import argparse
+import atexit
 import json
 import os
+import re
+import sys
 
 from config import WORKDIR, NODE, PT_BASEDIR, BASEDIR, SERVER, PXC_LOWER_BASE, PXC_UPPER_BASE
 from util import pxc_startup, ps_startup
@@ -18,7 +21,36 @@ parser.add_argument('-e', '--encryption-run', action='store_true',
 parser.add_argument('-d', '--debug', action='store_true',
                     help='This option will enable debug logging')
 
-args = parser.parse_args()
+args, extra_args = parser.parse_known_args()
+
+worker_id = 0
+for extra_arg in extra_args:
+    if re.fullmatch(r'-[1-9][0-9]*', extra_arg):
+        if worker_id != 0:
+            parser.error('Only one worker option can be specified')
+        worker_id = int(extra_arg[1:])
+    else:
+        parser.error('unrecognized arguments: ' + extra_arg)
+
+if worker_id > 0:
+    workdir = workdir + "/w" + str(worker_id)
+
+tests_log_dir = workdir + "/log" + "/tests_log"
+os.makedirs(tests_log_dir, exist_ok=True)
+test_name = os.path.splitext(os.path.basename(sys.argv[0]))[0]
+test_log = open(tests_log_dir + "/" + test_name + ".log", "a", buffering=1)
+sys.stdout = test_log
+sys.stderr = test_log
+
+
+def _restore_test_logging():
+    sys.stdout = sys.__stdout__
+    sys.stderr = sys.__stderr__
+    test_log.close()
+
+
+atexit.register(_restore_test_logging)
+
 encryption = args.encryption_run
 
 debug = 'NO'
@@ -57,6 +89,18 @@ class BaseTest:
         self.node2: DbConnection = None
         self.node3: DbConnection = None
         self.ps_nodes: list[DbConnection] = None
+        self._shutdown_registered = False
+
+    def _register_shutdown_on_exit(self):
+        if not self._shutdown_registered:
+            atexit.register(self._shutdown_on_exit)
+            self._shutdown_registered = True
+
+    def _shutdown_on_exit(self):
+        if self.pxc_nodes:
+            self.shutdown_nodes(self.pxc_nodes)
+        if self.ps_nodes:
+            self.shutdown_nodes(self.ps_nodes)
 
     def start_pxc(self, my_extra: str = None, custom_conf_settings: dict = None,
                   terminate_on_startup_failure: bool = True):
@@ -66,7 +110,7 @@ class BaseTest:
             my_extra_options = self.__my_extra
 
         # Start PXC cluster
-        server_startup = pxc_startup.StartCluster(self.__number_of_nodes, debug, self.__version)
+        server_startup = pxc_startup.StartCluster(self.__number_of_nodes, debug, self.__version, worker_id)
         server_startup.sanity_check()
         if encryption or self.encrypt:
             server_startup.create_config('encryption', self.__wsrep_provider_options,
@@ -81,6 +125,7 @@ class BaseTest:
         if self.__extra_config_file is not None:
             server_startup.add_myextra_configuration(self.__extra_config_file)
         self.pxc_nodes = server_startup.start_cluster(my_extra_options, terminate_on_startup_failure)
+        self._register_shutdown_on_exit()
         if len(self.pxc_nodes) == self.__number_of_nodes:
             self.node1 = self.pxc_nodes[0]
             self.node2 = self.pxc_nodes[1]
@@ -94,7 +139,6 @@ class BaseTest:
         if debug == 'YES':
             for node in self.pxc_nodes:
                 print("node is " + node.get_socket())
-        # atexit.register(shutdown_nodes(self.node))
 
     def start_ps(self, my_extra=None):
         """ Start Percona Server. This method will
@@ -105,7 +149,7 @@ class BaseTest:
             my_extra_options = my_extra
         else:
             my_extra_options = self.__my_extra
-        server_startup = ps_startup.StartPerconaServer(self.__number_of_nodes, debug, self.__version)
+        server_startup = ps_startup.StartPerconaServer(self.__number_of_nodes, debug, self.__version, worker_id)
         server_startup.test_sanity_check()
         if encryption or self.encrypt:
             server_startup.create_config('encryption')
@@ -115,6 +159,8 @@ class BaseTest:
         if self.__extra_config_file is not None:
             server_startup.add_myextra_configuration(self.__extra_config_file)
         self.ps_nodes = server_startup.start_server(my_extra_options)
+        if self.ps_nodes:
+            self._register_shutdown_on_exit()
 
     def shutdown_nodes(self, nodes=None):
         if nodes is None:

--- a/doc/correctness.md
+++ b/doc/correctness.md
@@ -7,12 +7,27 @@ This script will check following testcases.
 * ChaosMonkey style QA
 * Cluster Interaction QA
 
-Note : We can also enable encryption options with the argument `--encryption-run`
+Encryption can be enabled with `--encryption-run`. Debug logging uses `--debug`.
+
+Running tests
+-------------
+
+Run the full correctness suite:
+
+```bash
+python3 qa_framework.py --suites=correctness
+```
+
+Run a single test:
+
+```bash
+python3 qa_framework.py --tests=correctness.cluster_interaction.py
+```
 
 Correctness QA run log
 ----------------------
 ```
-$ python3 pxc_qa_framework.py  --suite=correctness
+$ python3 qa_framework.py --suites=correctness
 ---------------------------------------------------
 Crash recovery QA using forceful mysqld termination
 ---------------------------------------------------
@@ -90,7 +105,7 @@ PXC ChaosMonkey Style test
 07:42:50  pt-table-checksum run status                                                                        [ ✔ ]
 $
 
-$ ./suite/correctness/cluster_interaction.py
+$ python3 qa_framework.py --tests=correctness.cluster_interaction.py
 ----------------------------------------------
 Cluster interaction QA using flow control test
 ----------------------------------------------

--- a/doc/galera_streamin_replication.md
+++ b/doc/galera_streamin_replication.md
@@ -1,11 +1,27 @@
 Streaming Replication QA script
 ---------------------
-This suite will test streaming replication feature.
+This suite tests Galera streaming replication and thread-pool combinations.
+
+Running tests
+-------------
+
+Run the full `galera_sr` suite:
+
+```bash
+python3 qa_framework.py --suites=galera_sr
+```
+
+Run individual tests:
+
+```bash
+python3 qa_framework.py --tests=galera_basic_sr_qa.py
+python3 qa_framework.py --tests=galera_sr.thread_pool_qa.py
+```
 
 Streaming replication run log
 -----------------------------
 ```
-$ python3 qa_framework.py --testname=suite/galera_sr/galera_basic_sr_qa.py
+$ python3 qa_framework.py --tests=galera_basic_sr_qa.py
 --------------------------------
 
 PXC Streaming Replication test
@@ -27,7 +43,7 @@ PXC Streaming Replication test
 01:26:32  SR testcase( DML row count 10000, fragment_unit : bytes, fragment_size : 2 )                        [ ✓ ]
 [..]
 
-$ python3 qa_framework.py --testname=suite/galera_sr/thread_pool_qa.py
+$ python3 qa_framework.py --tests=galera_sr.thread_pool_qa.py
 --------------------------------
 
 PXC Thread Pooling test

--- a/doc/random_qa.md
+++ b/doc/random_qa.md
@@ -1,16 +1,40 @@
 Random QA script
 -------------
 
-This script is a small test and not a suite. pxc_util.py will start a 3 node cluster. We can configure it to start 3 node cluster with different options apart from the default. 
-If we need to start cluster with `innodb-buffer-pool-size=128M` then we can edit pxc_util.py as below 
-result = server_startup.start_cluster('--innodb-buffer-pool-size=128M ')
-We can also enable encryption options with `--encryption-run`
-We can also enable debug options with `--debug`
+This suite contains standalone stress and option-randomization tests. The helper
+script `util/pxc_util.py` can start a 3-node cluster for manual testing. To
+start a cluster with a custom option such as `--innodb-buffer-pool-size=128M`,
+edit the `start_cluster()` call in `util/pxc_util.py`.
+
+Encryption can be enabled with `--encryption-run`. Debug logging uses `--debug`.
+
+Running tests
+-------------
+
+Run the full random_qa suite:
+
+```bash
+python3 qa_framework.py --suites=random_qa
+```
+
+Run individual tests:
+
+```bash
+python3 qa_framework.py --tests=random_qa.random_mysqld_option_test.py
+python3 qa_framework.py --tests=random_qa.pstress_crash_recovery_qa.py
+python3 qa_framework.py --tests=random_qa.pstress_random_qa.py
+```
+
+Start a cluster manually with the utility script:
+
+```bash
+python3 util/pxc_util.py --start --debug
+```
 
 Random QA run log
 --------------
 ```
-$ python3 suite/random_qa/pxc_util.py --start --debug
+$ python3 util/pxc_util.py --start --debug
 
 13:26:04  Startup sanity check                                                                                [ ✓ ]
 13:26:04  Configuration file creation                                                                         [ ✓ ]
@@ -33,7 +57,7 @@ $ python3 suite/random_qa/pxc_util.py --start --debug
 	/dev/shm/qa/Percona-XtraDB-Cluster_8.0.26-16.1_Linux.x86_64.glibc2.17/bin/mysql --user=root --socket=/dev/shm/qa/node3/mysql.sock
 
 
-$ python3 qa_framework.py --testname=suite/random_qa/random_mysqld_option_test.py
+$ python3 qa_framework.py --tests=random_qa.random_mysqld_option_test.py
 ------------------------------
 PXC Random MySQLD options test
 ------------------------------
@@ -142,7 +166,7 @@ PXC Random MySQLD options test
 [...]
 
 
-$ python3 qa_framework.py --testname=suite/random_qa/pstress_crash_recovery_qa.py
+$ python3 qa_framework.py --tests=random_qa.pstress_crash_recovery_qa.py
 --------------------
 PXC Random PSTRESS QA
 --------------------
@@ -174,7 +198,7 @@ PXC Random PSTRESS QA
 06:42:11  PSTRESS RUN command : /home/vagrant/pstress/src/pstress-pxc --database=test --threads=10 --logdir=/dev/shm/qa/log --log-all-queries --log-failed-queries --user=root --socket=/dev/shm/qa/node1/mysql.sock --seed 1000 --tables 5 --records 10 --no-encryption --seconds 30 --grammar-file /home/vagrant/pstress/src/grammar.sql --step 6 > /dev/shm/qa/log/pstress_run.log[ ✓ ]
 
 
-$ python3 qa_framework.py --testname=suite/random_qa/pstress_random_qa.py
+$ python3 qa_framework.py --tests=random_qa.pstress_random_qa.py
 
 --------------------
 PXC Random PSTRESS QA

--- a/doc/replication.md
+++ b/doc/replication.md
@@ -1,18 +1,33 @@
 Replication QA script
 ---------------------
-This suite will cover following replication testcases. To enable encryption options you should use 
-the argument `--encryption-run` with pxc qa framework.
+This suite covers the following replication testcases. Encryption can be enabled with
+`--encryption-run`.
 
-* PXC node as master and PS node as slave (GTID and Non-GTID)
-* PXC node as slave and PS node as master (GTID and Non-GTID)
-* Multi source replication - PXC node act as multi master slave (GTID and Non-GTID)
-* Multi thread replication - PXC node act as multi thread slave (GTID and Non-GTID)
+* PXC node as source and PS node as replica (GTID and Non-GTID)
+* PXC node as replica and PS node as source (GTID and Non-GTID)
+* Multi source replication - PXC node act as multi source replica (GTID and Non-GTID)
+* Multi thread replication - PXC node act as multi thread replica (GTID and Non-GTID)
 * Configure replication using Percona Xtrabackup
+
+Running tests
+-------------
+
+Run the full replication suite:
+
+```bash
+python3 qa_framework.py --suites=replication
+```
+
+Run a single test:
+
+```bash
+python3 qa_framework.py --tests=replication.replication.py
+```
 
 Replication suite log
 ---------------------
 ```
-$ python3 pxc_qa_framework.py  --suite=replication
+$ python3 qa_framework.py --suites=replication
 
 GTID PXC Node as Master and PS node as Slave
 ----------------------------------------------
@@ -163,4 +178,4 @@ NON-GTID PXC Node as Slave and PS node as Master
 07:18:59  PXC: IO thread slave status                                                                         [ ✔ ]
 07:18:59  PXC: SQL thread slave status                                                                        [ ✔ ]
 $
-````
+```

--- a/doc/ssl.md
+++ b/doc/ssl.md
@@ -1,13 +1,28 @@
 SSL QA script
 -------------
 
-This script will enable SSL configurations for SST, data transfer and client server connection. 
-We can also enable encryption options with `--encryption-run`
+This suite enables SSL configurations for SST, data transfer, and client-server
+connections. Encryption can be enabled with `--encryption-run`.
+
+Running tests
+-------------
+
+Run the full SSL suite:
+
+```bash
+python3 qa_framework.py --suites=ssl
+```
+
+Run the encryption test only:
+
+```bash
+python3 qa_framework.py --tests=ssl.encryption_qa.py --encryption-run
+```
 
 SSL QA run log
 --------------
 ```
-$ python3 pxc_qa_framework.py  --suite=ssl
+$ python3 qa_framework.py --suites=ssl
 
 PXC SSL test
 --------------

--- a/doc/sysbench_loadtest.md
+++ b/doc/sysbench_loadtest.md
@@ -1,6 +1,8 @@
 Sysbench Loadtest QA script
 ---------------------------
-This suite will help us to test the workload in Percona XtraDB Cluster. To enable encryption options you should use the argument --encryption-run with pxc qa framework.
+This suite tests workload in Percona XtraDB Cluster. Encryption can be enabled
+with `--encryption-run`. Sysbench data sizes can be customized in
+[config.ini](../config.ini).
 
 Currently we are using following sysbench testsuite for workload test.
 * sysbench_customized_dataload_test.py
@@ -16,12 +18,25 @@ Currently we are using following sysbench testsuite for workload test.
 * sysbench_wsrep_provider_option_random_test.py
   * This testsuite will help us to test PXC with different wsrep provider options
 
-PS : We can customize the sysbench data size through [config.ini](../config.ini)
+Running tests
+-------------
+
+Run all loadtest and sysbench_run suite tests:
+
+```bash
+python3 qa_framework.py --suites=loadtest,sysbench_run
+```
+
+Run a single test:
+
+```bash
+python3 qa_framework.py --tests=loadtest.sysbench_load_test.py
+```
 
 Sysbench Loadtest suite log
 ---------------------
 ```
-python3 qa_framework.py --testname=suite/loadtest/sysbench_wsrep_provider_option_random_test.py
+$ python3 qa_framework.py --tests=loadtest.sysbench_wsrep_provider_option_random_test.py
 
 --------------------------------
 
@@ -39,7 +54,7 @@ PXC WSREP provider random test
 16:41:47  PXC: shutting down cluster node1                                                                    [ ✓ ]
 
 
-python3 qa_framework.py --testname=suite/loadtest/sysbench_load_test.py
+python3 qa_framework.py --tests=loadtest.sysbench_load_test.py
 
 -------------------------
 
@@ -71,7 +86,7 @@ PXC sysbench load test
 16:59:37  PXC: shutting down cluster node1                                                                    [ ✓ ]
 
 
-python3 qa_framework.py --testname=suite/loadtest/sysbench_random_load_test.py
+python3 qa_framework.py --tests=loadtest.sysbench_random_load_test.py
 
 -------------------------------
 
@@ -87,7 +102,7 @@ PXC sysbench random load test
 17:00:44  Sysbench data load (threads : 50)                                                                   [ ✓ ]
 
 
-python3 qa_framework.py --testname=suite/sysbench_run/sysbench_customized_dataload_test.py
+python3 qa_framework.py --tests=sysbench_run.sysbench_customized_dataload_test.py
 
 ----------------------------------------
 
@@ -105,7 +120,7 @@ PXC sysbench customized data load test
 10:35:37  PXC: shutting down cluster node1                                                                    [ ✓ ]
 
 
-python3 qa_framework.py --testname=suite/sysbench_run/sysbench_oltp_test.py
+python3 qa_framework.py --tests=sysbench_run.sysbench_oltp_test.py
 
 ------------------------
 
@@ -128,7 +143,7 @@ PXC sysbench oltp test
 10:41:12  Checksum run for DB: test                                                                           [ ✓ ]
 
 
-python3 qa_framework.py --testname=suite/sysbench_run/sysbench_read_only_test.py
+python3 qa_framework.py --tests=sysbench_run.sysbench_read_only_test.py
 
 -----------------------------
 

--- a/doc/upgrade.md
+++ b/doc/upgrade.md
@@ -1,7 +1,23 @@
 Upgrade QA script
 ---------------------
-This suite will help us to test Percona XtraDB Cluster upgrade. You should pass PXC base directory locations in [config.ini](../config.ini) file  To enable encryption options you should use 
-the argument `--encryption-run` with pxc qa framework.
+This suite tests Percona XtraDB Cluster upgrade. Configure lower and upper PXC
+tarball paths in [config.ini](../config.ini) under the `[upgrade]` section.
+Encryption can be enabled with `--encryption-run`.
+
+Running tests
+-------------
+
+Run the full upgrade suite:
+
+```bash
+python3 qa_framework.py --suites=upgrade
+```
+
+Run a single upgrade test:
+
+```bash
+python3 qa_framework.py --tests=upgrade.pxc_upgrade.py
+```
 
 Upgrade suite log
 ------------------

--- a/qa_framework.py
+++ b/qa_framework.py
@@ -4,74 +4,335 @@
 
 import os
 import argparse
+import concurrent.futures
+import queue
 import shutil
+import subprocess
 import sys
+import threading
 from config import *
+
+workdir = WORKDIR
+
+SUITES = ['sysbench_run', 'loadtest', 'replication', 'correctness', 'ssl', 'upgrade',
+          'random_qa', 'galera_sr']
+
+EXCLUDED_DEFAULT_SUITES = {'loadtest', 'random_qa', 'upgrade'}
+DEFAULT_SUITES = [suite for suite in SUITES if suite not in EXCLUDED_DEFAULT_SUITES]
+GLOBAL_MANIFEST_AND_CONFIG_TESTS = ['encryption_qa.py']
+
+# Serializes the stdout+file write pair so concurrent workers can't interleave
+# a single message across the console and the results file.
+_output_lock = threading.Lock()
+
+
+def log_output(message, tc_output, flush=True):
+    with _output_lock:
+        print(message, flush=flush)
+        print(message, file=tc_output, flush=flush)
+
+
+def parse_csv_values(value):
+    if not value:
+        return []
+    return [item.strip() for item in value.split(',') if item.strip()]
+
+
+def validate_suite(scriptdir, suite):
+    if suite not in SUITES:
+        print('Suite ' + suite + ' is not valid. Valid suites: ' + ', '.join(SUITES))
+        exit(1)
+    if not os.path.exists(scriptdir + '/suite/' + suite):
+        print('Suite ' + suite + '(' + scriptdir + '/suite/' + suite + ') does not exist')
+        exit(1)
+
+
+def get_qualified_test(test):
+    for suite in SUITES:
+        suite_prefix = suite + '.'
+        if test.startswith(suite_prefix):
+            test_file_name = test[len(suite_prefix):]
+            if test_file_name.endswith('.py'):
+                return suite, test_file_name
+    return None, os.path.basename(test)
+
+
+def get_disabled_tests(scriptdir):
+    disabled_file = scriptdir + '/disabled.list'
+    disabled_qualified = set()
+    disabled_any_suite = set()
+    if not os.path.isfile(disabled_file):
+        return disabled_qualified, disabled_any_suite
+    with open(disabled_file, 'r') as handle:
+        for line in handle:
+            entry = line.strip()
+            if not entry or entry.startswith('#'):
+                continue
+            if not entry.endswith('.py'):
+                continue
+            test_suite, test_file_name = get_qualified_test(entry)
+            if test_suite:
+                disabled_qualified.add((test_suite, test_file_name))
+            else:
+                disabled_any_suite.add(test_file_name)
+    return disabled_qualified, disabled_any_suite
+
+
+def filter_disabled_tests(test_runs, disabled_tests, tc_output):
+    disabled_qualified, disabled_any_suite = disabled_tests
+    if not disabled_qualified and not disabled_any_suite:
+        return test_runs
+    filtered_test_runs = []
+    for test_run in test_runs:
+        test_name = os.path.basename(test_run[0])
+        suite_name = test_run[1]
+        if test_name in disabled_any_suite or (suite_name, test_name) in disabled_qualified:
+            message = 'Skipping disabled test ' + suite_name + '.' + test_name
+            log_output(message, tc_output)
+            continue
+        filtered_test_runs.append(test_run)
+    log_output("", tc_output)
+    return filtered_test_runs
+
+
+def is_global_manifest_and_config_test(test_run):
+    return os.path.basename(test_run[0]) in GLOBAL_MANIFEST_AND_CONFIG_TESTS
+
+
+def filter_global_manifest_and_config_tests(test_runs, tc_output):
+    global_manifest_and_config_runs = [test_run for test_run in test_runs if is_global_manifest_and_config_test(test_run)]
+    if not global_manifest_and_config_runs or len(test_runs) == len(global_manifest_and_config_runs):
+        return test_runs
+    filtered_test_runs = []
+    for test_run in test_runs:
+        if is_global_manifest_and_config_test(test_run):
+            suite_name = test_run[1]
+            test_name = os.path.basename(test_run[0])
+            message = ('Skipping ' + suite_name + '.' + test_name +
+                       ' - cannot run together with other tests in encryption mode '
+                       'as it changes the global keyring file')
+            log_output(message, tc_output)
+            continue
+        filtered_test_runs.append(test_run)
+    log_output("", tc_output)
+    return filtered_test_runs
+
+
+def find_test_runs(scriptdir, tests, suites, tc_output):
+    test_runs = []
+    search_suites = suites
+    if len(search_suites) == 0:
+        search_suites = SUITES
+    log_output("#" * 80, tc_output)
+    for test in tests:
+        test_suite, test_file_name = get_qualified_test(test)
+        if test_suite:
+            validate_suite(scriptdir, test_suite)
+            test_file = scriptdir + '/suite/' + test_suite + '/' + test_file_name
+            if not os.path.isfile(test_file):
+                print(test + ' does not exist')
+                exit(1)
+            log_output("Adding test " + test_file, tc_output)
+            test_runs.append((test_file, test_suite))
+            continue
+
+        test_found = False
+        for suite in search_suites:
+            test_file = scriptdir + '/suite/' + suite + '/' + test_file_name
+            if os.path.isfile(test_file):
+                log_output("Adding test " + test_file, tc_output)
+                test_runs.append((test_file, suite))
+                test_found = True
+        if not test_found:
+            print(test_file_name + ' does not exist in specified suites')
+            exit(1)
+    log_output("", tc_output)
+    return test_runs
+
+
+def add_suite_test_runs(scriptdir, suites, tc_output, debug):
+    test_runs = []
+    log_output("#" * 80, tc_output)
+    for suite in suites:
+        log_output("Adding tests from " + suite + " suite", tc_output)
+        for file in os.listdir(scriptdir + '/suite/' + suite):
+            if file.endswith(".py"):
+                if debug:
+                    log_output("Adding test " + scriptdir + '/suite/' + suite + '/' + file, tc_output)
+                test_runs.append((scriptdir + '/suite/' + suite + '/' + file, suite))
+        log_output("", tc_output)
+    return test_runs
+
+def make_workdir(number_of_workers=0):
+    if os.path.exists(workdir):
+        print('Work directory ' + workdir + ' already exists, removing it')
+        shutil.rmtree(workdir, ignore_errors=True)
+    print('Creating work directory ' + workdir)
+    os.makedirs(workdir)
+    if number_of_workers > 0:
+        for worker_id in range(1, number_of_workers + 1):
+            worker_dir = get_worker_thread_dir(worker_id)
+            os.makedirs(worker_dir)
+            os.makedirs(worker_dir + '/log')
+            os.makedirs(worker_dir + '/conf')
+            os.makedirs(worker_dir + '/failed_logs')
+            os.makedirs(worker_dir + '/log' + '/tests_log')
+    else:
+        os.makedirs(workdir + '/log')
+        os.makedirs(workdir + '/conf')
+        os.makedirs(workdir + '/failed_logs')
+        os.makedirs(workdir + '/log' + '/tests_log')
+
+def get_worker_thread_dir(worker_id=0):
+    if worker_id > 0:
+        return workdir + '/w' + str(worker_id)
+    return workdir
+
+
+def run_test(test_file, suite_name, encryption, tc_output, debug, worker_id=0):
+    cmd = test_file
+    if encryption:
+        cmd = cmd + ' -e'
+    if debug:
+        cmd = cmd + ' -d'
+    worker_option = ''
+    if worker_id > 0:
+        worker_option = '-' + str(worker_id)
+    if worker_option:
+        cmd = cmd + ' ' + worker_option
+    if debug:
+        log_output("Running test : " + cmd, tc_output)
+    result = subprocess.call(cmd, shell=True)
+    return worker_id, suite_name, os.path.basename(test_file), result
+
+
+def run_worker_tests(worker_id, test_queue, encryption, debug, tc_output, output_lock):
+    worker_failed = False
+    while True:
+        try:
+            test_run = test_queue.get_nowait()
+        except queue.Empty:
+            break
+        try:
+            result = run_test(test_run[0], test_run[1], encryption, tc_output, debug, worker_id)
+            with output_lock:
+                worker_failed = handle_test_result(tc_output, *result) or worker_failed
+        finally:
+            test_queue.task_done()
+    return worker_failed
+
+
+def handle_test_result(tc_output, worker_id, suite_name, file, result):
+    worker = ''
+    if worker_id > 0:
+        worker = 'w' + str(worker_id) + ' '
+    test_name = f'{suite_name}.{file}'
+    if result == 0:
+        output = 'Test ' + f'{test_name:60}' + worker + '[Pass]'
+    else:
+        output = 'Test ' + f'{test_name:60}' + worker + '[Fail]'
+    log_output(output, tc_output)
+    if result != 0:
+        workdir = get_worker_thread_dir(worker_id)
+        print_failed_test_log(tc_output, workdir, file)
+        os.system('tar -czf ' + workdir + '/failed_logs/' + suite_name + '_' +
+                  file + '.tar.gz ' + workdir + '/log/*')
+    return result != 0
+
+
+def print_failed_test_log(tc_output, workdir, file, num_lines=10):
+    test_log_file = workdir + '/log' + '/tests_log/' + os.path.splitext(file)[0] + '.log'
+    header = 'Test results at the time of failure:'
+    if not os.path.isfile(test_log_file):
+        message = 'Failed test log file not found: ' + test_log_file
+        log_output(message, tc_output)
+        return
+    from collections import deque
+    with open(test_log_file, 'r', errors='replace') as log_file:
+        last_lines = list(deque(log_file, maxlen=num_lines))
+    log_output(header, tc_output)
+    for line in last_lines:
+        log_output(line.rstrip('\n'), tc_output)
+    log_output("Check the log file for more details: " + test_log_file, tc_output)
+
 
 def main():
     """ This function will help us to run PS/PXC QA scripts.
         We can initiate complete test suite or individual
         testcase using this function.
     """
-    tc_output = open('qa_framework_tc_status.out', 'w')
+    tc_output_file = 'test_run_results.out'
+    tc_output = open(tc_output_file, 'w')
     scriptdir = os.path.dirname(os.path.realpath(__file__))
     parser = argparse.ArgumentParser(prog='QA Framework', usage='%(prog)s [options]')
-    parser.add_argument('-t', '--testname', help='Specify test file location')
-    parser.add_argument('-p', '--product', default='pxc', choices=['pxc', 'ps'],
-                        help='Specify product(PXC/PS) name to test')
-    parser.add_argument('-s', '--suite', default='',
-                        choices=['sysbench_run', 'loadtest', 'replication', 'correctness', 'ssl', 'upgrade',
-                                 'random_qa', 'galera_sr'],
-                        help='Specify suite name', nargs='*')
+    parser.add_argument('-t', '--tests', '--test', default='', dest='tests',
+                        help='Specify comma-separated test file names or suite.test_file.py names')
+    parser.add_argument('-s', '-S', '--suites', '--suite', default='', dest='suites',
+                        help='Specify comma-separated suite names (default: all suites except '
+                             + ', '.join(sorted(EXCLUDED_DEFAULT_SUITES)) + ' when -t is not used)')
     parser.add_argument('-e', '--encryption-run', action='store_true',
                         help='This option will enable encryption options')
     parser.add_argument('-d', '--debug', action='store_true',
                         help='This option will enable debug logging')
-    if len(sys.argv) == 1:
-        parser.print_help(sys.stderr)
+    parser.add_argument('-w', '--number-of-workers', type=int, default=0,
+                        help='Specify number of workers to run the test suite in parallel')
+    args = parser.parse_args()
+    encryption = args.encryption_run
+    debug = args.debug
+    tests = parse_csv_values(args.tests)
+    suites = parse_csv_values(args.suites)
+    number_of_workers = args.number_of_workers
+    test_runs = []
+    for suite in suites:
+        validate_suite(scriptdir, suite)
+
+    if len(tests) == 0:
+        if len(suites) == 0:
+            suites = DEFAULT_SUITES
+            log_output('Running default suites: ' + ', '.join(suites), tc_output)
+        test_runs.extend(add_suite_test_runs(scriptdir, suites, tc_output, debug))
+    else:
+        test_runs.extend(find_test_runs(scriptdir, tests, suites, tc_output))
+
+    test_runs = filter_disabled_tests(test_runs, get_disabled_tests(scriptdir), tc_output)
+    if encryption:
+        test_runs = filter_global_manifest_and_config_tests(test_runs, tc_output)
+
+    if len(test_runs) != 0:
+        make_workdir(number_of_workers)
+    else:
+        print('Either no test passed to run or no test found in specified suites to run')
+        tc_output.close()
         sys.exit(1)
 
-    args = parser.parse_args()
-    if args.encryption_run is True:
-        encryption = '-e'
+    log_output("#" * 80 + "\n", tc_output)
+
+    any_failed = False
+    if number_of_workers > 0:
+        test_queue = queue.Queue()
+        for test_run in test_runs:
+            test_queue.put(test_run)
+        output_lock = threading.Lock()
+        with concurrent.futures.ThreadPoolExecutor(max_workers=number_of_workers) as executor:
+            futures = [executor.submit(run_worker_tests, worker_id, test_queue, encryption, debug,
+                                       tc_output, output_lock)
+                       for worker_id in range(1, number_of_workers + 1)]
+            for future in concurrent.futures.as_completed(futures):
+                any_failed = future.result() or any_failed
     else:
-        encryption = ''
-    if args.debug is True:
-        debug = '-d'
-    else:
-        debug = ''
-    test_name = args.testname
-    suite = args.suite
-    if len(suite) != 0:
-        if not os.path.exists(WORKDIR + '/failed_logs'):
-            os.mkdir(WORKDIR + '/failed_logs')
-        else:
-            shutil.rmtree(WORKDIR + '/failed_logs', ignore_errors=True)
-            os.mkdir(WORKDIR + '/failed_logs')
-    for i in suite:
-        if i:
-            if not os.path.exists(scriptdir + '/suite/' + i):
-                print('Suite ' + i + '(' + scriptdir + '/suite/' + i + ') does not exist')
-                exit(1)
-            print("Running " + i + " QA framework")
-            for file in os.listdir(scriptdir + '/suite/' + i):
-                if file.endswith(".py"):
-                    result = os.system(scriptdir + '/suite/' + i + '/' + file + ' ' + encryption + ' ' + debug)
-                    if result == 0:
-                        tc_output.write('Test run ' + f'{file:50}' + 'passed\n')
-                    else:
-                        tc_output.write('Test run ' + f'{file:50}' + 'failed\n')
-                        os.system('tar -czf ' + WORKDIR + '/failed_logs/' + i + '_' +
-                                  file + '.tar.gz ' + WORKDIR + '/log/*')
+        for test_run in test_runs:
+            any_failed = handle_test_result(tc_output, *run_test(test_run[0], test_run[1],
+                                                                 encryption, tc_output, debug))
 
     tc_output.close()
-    if test_name is not None:
-        if not os.path.isfile(test_name):
-            print(test_name + ' does not exist')
-            exit(1)
-        else:
-            os.system(scriptdir + '/' + test_name + ' ' + encryption + ' ' + debug)
-
+    if os.path.isdir(workdir):
+        shutil.copy(tc_output_file, workdir)
+    if any_failed:
+        print('Some of the tests failed in the test run, please check the log file for more details')
+        sys.exit(1)
+    else:
+        print('All tests passed in the test run')
+        sys.exit(0)
 
 if __name__ == "__main__":
     main()

--- a/suite/correctness/chaosmonkey-test.py
+++ b/suite/correctness/chaosmonkey-test.py
@@ -20,7 +20,7 @@ class ChaosMonkeyQA(BaseTest):
 
     def sysbench_run(self):
         # Sysbench dataload for consistency test
-        sysbench = sysbench_run.SysbenchRun(self.node1, debug)
+        sysbench = sysbench_run.SysbenchRun(self.node1, debug, workdir)
 
         sysbench.test_sanity_check(db)
         sysbench.test_sysbench_load(db)
@@ -42,7 +42,7 @@ class ChaosMonkeyQA(BaseTest):
             for n in rand_nodes:
                 print(str(n))
         self.sysbench_run()
-        sysbench_pid = utility.sysbench_pid()
+        sysbench_pid = utility.sysbench_pid(self.node1)
         for j in rand_nodes:
             utility_cmd.kill_cluster_node(j)
         utility_cmd.kill_process(sysbench_pid, "sysbench otlp run")

--- a/suite/correctness/cluster_interaction.py
+++ b/suite/correctness/cluster_interaction.py
@@ -25,7 +25,7 @@ class ClusterInteraction(BaseTest):
 
     def sysbench_run(self, db, background_run=False):
         # Sysbench dataload for cluster interaction test
-        sysbench = sysbench_run.SysbenchRun(self.node1, debug)
+        sysbench = sysbench_run.SysbenchRun(self.node1, debug, workdir)
         sysbench.test_sanity_check(db)
         sysbench.test_sysbench_load(db, SYSBENCH_TABLE_COUNT, SYSBENCH_THREADS, SYSBENCH_NORMAL_TABLE_SIZE)
         if encryption:
@@ -42,7 +42,7 @@ class ClusterInteraction(BaseTest):
             3) Node joining
         """
         self.sysbench_run(db, True)
-        sysbench_pid = utility.sysbench_pid()
+        sysbench_pid = utility.sysbench_pid(self.node1)
         if int(version) > int("050700"):
             utility_cmd.check_testcase(0, "Initiating flow control test")
             #for j in range(1, 2):

--- a/suite/correctness/consistency_check.py
+++ b/suite/correctness/consistency_check.py
@@ -21,7 +21,7 @@ class ConsistencyCheck(BaseTest):
 
     def sysbench_run(self):
         # Sysbench dataload for consistency test
-        sysbench = sysbench_run.SysbenchRun(self.node1, debug)
+        sysbench = sysbench_run.SysbenchRun(self.node1, debug, workdir)
 
         sysbench.test_sanity_check(db)
         sysbench.test_sysbench_load(db, SYSBENCH_TABLE_COUNT, SYSBENCH_THREADS, SYSBENCH_NORMAL_TABLE_SIZE)

--- a/suite/correctness/crash_recovery.py
+++ b/suite/correctness/crash_recovery.py
@@ -27,7 +27,7 @@ class CrashRecovery(BaseTest):
 
     def sysbench_run(self):
         # Sysbench dataload for consistency test
-        sysbench = sysbench_run.SysbenchRun(self.node1, debug)
+        sysbench = sysbench_run.SysbenchRun(self.node1, debug, workdir)
 
         sysbench.test_sanity_check(db)
         sysbench.test_sysbench_load(db, SYSBENCH_TABLE_COUNT, SYSBENCH_THREADS, SYSBENCH_NORMAL_TABLE_SIZE)
@@ -46,7 +46,7 @@ class CrashRecovery(BaseTest):
                 while active data load in primary node
         """
         self.sysbench_run()
-        sysbench_pid = utility.sysbench_pid()
+        sysbench_pid = utility.sysbench_pid(self.node1)
         if test_name == "with_force_kill":
             time.sleep(10)
             utility_cmd.kill_cluster_node(self.node3)
@@ -72,10 +72,10 @@ class CrashRecovery(BaseTest):
                 utility_cmd.check_testcase(result, "Shutdown cluster node for crash recovery")
                 time.sleep(10)
                 restart_node_check_recovery_status(self.node3)
-                sysbench_pid = utility.sysbench_pid()
+                sysbench_pid = utility.sysbench_pid(self.node1)
                 if not sysbench_pid:
                     self.sysbench_run()
-                    sysbench_pid = utility.sysbench_pid()
+                    sysbench_pid = utility.sysbench_pid(self.node1)
                     time.sleep(5)
                 utility_cmd.kill_process(sysbench_pid, "sysbench", True)
 

--- a/suite/galera_sr/galera_basic_sr_qa.py
+++ b/suite/galera_sr/galera_basic_sr_qa.py
@@ -28,7 +28,7 @@ class StreamingReplication(BaseTest):
             checksum = table_checksum.TableChecksum(self.node1, workdir, pt_basedir, debug)
             checksum.sanity_check(self.pxc_nodes)
 
-        sysbench = sysbench_run.SysbenchRun(self.node1, debug)
+        sysbench = sysbench_run.SysbenchRun(self.node1, debug, workdir)
         sysbench.test_sanity_check(db)
         sysbench.test_sysbench_load(db, SYSBENCH_TABLE_COUNT, SYSBENCH_THREADS, SYSBENCH_LOAD_TEST_TABLE_SIZE)
 
@@ -48,7 +48,7 @@ class StreamingReplication(BaseTest):
             if debug == 'YES':
                 print("call " + db + ".sr_procedure")
             proc_args = [str(rows), trx_fragment_unit, str(trx_fragment_size)]
-            self.node1.call_proc(db + '.sr_procedure', proc_args)
+            self.node1.call_proc(db + '.sr_procedure', proc_args, innodb_lock_wait_timeout=180)
 
             sr_combination = "DML row count " + proc_args[0] + ", fragment_unit : " + \
                              proc_args[1] + ", fragment_size : " + proc_args[2]

--- a/suite/galera_sr/thread_pool_qa.py
+++ b/suite/galera_sr/thread_pool_qa.py
@@ -30,7 +30,7 @@ class ThreadPooling(BaseTest):
             checksum = table_checksum.TableChecksum(self.node1, workdir, pt_basedir, debug)
             checksum.sanity_check(self.pxc_nodes)
 
-        sysbench = sysbench_run.SysbenchRun(self.node1, debug)
+        sysbench = sysbench_run.SysbenchRun(self.node1, debug, workdir)
         sysbench.test_sanity_check(db)
         sysbench.test_sysbench_load(db, 50, 50, SYSBENCH_NORMAL_TABLE_SIZE)
         # Sysbench OLTP read write run
@@ -48,14 +48,14 @@ class ThreadPooling(BaseTest):
                        " --thread_pool_max_threads=" + str(tp_max_thread)
             # Start PXC cluster for thread pooling test
             utility_cmd.check_testcase(0, "Thread pooling options : " + my_extra)
-            server_startup = pxc_startup.StartCluster(3, debug)
+            server_startup = pxc_startup.StartCluster(3, debug, worker_id=worker_id)
             server_startup.sanity_check()
             server_startup.create_config('none', set_admin_address=True)
             server_startup.initialize_cluster()
             self.pxc_nodes = server_startup.start_cluster(my_extra)
             self.node1 = self.pxc_nodes[0]
             utility_cmd.check_testcase(self.node1.connection_check(), "Database connection")
-            self.sysbench_run(33063)
+            self.sysbench_run(int(self.node1.get_admin_port()))
             self.shutdown_nodes(self.pxc_nodes)
 
 

--- a/suite/loadtest/sysbench_load_test.py
+++ b/suite/loadtest/sysbench_load_test.py
@@ -30,7 +30,7 @@ class SysbenchLoadTest(BaseTest):
             checksum = table_checksum.TableChecksum(nodes[0], workdir, pt_basedir, debug)
             checksum.sanity_check(nodes)
         for thread in threads:
-            sysbench = sysbench_run.SysbenchRun(nodes[0], debug)
+            sysbench = sysbench_run.SysbenchRun(nodes[0], debug, workdir)
             if thread == 32:
                 sysbench.test_sanity_check(db)
             sysbench.test_sysbench_cleanup(db, thread, thread, SYSBENCH_LOAD_TEST_TABLE_SIZE)

--- a/suite/loadtest/sysbench_random_load_test.py
+++ b/suite/loadtest/sysbench_random_load_test.py
@@ -29,7 +29,7 @@ class SysbenchRandomLoadTest(BaseTest):
         if int(version) < int("080000"):
             checksum = table_checksum.TableChecksum(nodes[0], workdir, pt_basedir, debug)
             checksum.sanity_check(nodes)
-        sysbench = sysbench_run.SysbenchRun(nodes[0], debug)
+        sysbench = sysbench_run.SysbenchRun(nodes[0], debug, workdir)
         sysbench.test_sanity_check(db)
         for table_count in tables:
             sysbench.test_sysbench_cleanup(db, table_count, table_count, SYSBENCH_RANDOM_LOAD_TABLE_SIZE)

--- a/suite/loadtest/sysbench_wsrep_provider_option_random_test.py
+++ b/suite/loadtest/sysbench_wsrep_provider_option_random_test.py
@@ -41,12 +41,12 @@ class WSREPProviderRandomTest(BaseTest):
 
             self.set_wsrep_provider_options(wsrep_provider_option)
             self.start_pxc()
-            sysbench = sysbench_run.SysbenchRun(self.node1, debug)
+            sysbench = sysbench_run.SysbenchRun(self.node1, debug, workdir)
             sysbench.test_sanity_check(db)
             sysbench.test_sysbench_load(db, use_load_table_size=True)
 
             sysbench.test_sysbench_oltp_read_write(db, time=300, background=True, use_load_table_size=True)
-            sysbench_pid = utility.sysbench_pid()
+            sysbench_pid = utility.sysbench_pid(self.node1)
             print("Sysbench pid : " + sysbench_pid)
             time.sleep(100)
             self.node2.shutdown()

--- a/suite/random_qa/pstress_crash_recovery_qa.py
+++ b/suite/random_qa/pstress_crash_recovery_qa.py
@@ -30,7 +30,7 @@ class RandomPstressQA(BaseTest):
             utility_cmd.pstress_run(socket=self.node1.get_socket(), db=db, seed=n, step_num=i,
                                     pstress_extra=pstress_extra, workdir=workdir)
             # kill existing mysqld process
-            utility_cmd.kill_cluster_nodes()
+            utility_cmd.kill_cluster_nodes(self.pxc_nodes)
             utility_cmd.restart_cluster(self.pxc_nodes)
 
 

--- a/suite/random_qa/random_mysqld_option_test.py
+++ b/suite/random_qa/random_mysqld_option_test.py
@@ -13,7 +13,7 @@ from util import sysbench_run
 from util import utility
 
 conf_file = parent_dir + '/conf/mysql_options_pxc80.txt'
-random_mysql_error_dir = WORKDIR + '/random_mysql_error'
+random_mysql_error_dir = workdir + '/random_mysql_error'
 
 
 class RandomMySQLDOptionQA(BaseTest):
@@ -22,7 +22,7 @@ class RandomMySQLDOptionQA(BaseTest):
 
     def data_load(self):
         # Sysbench data load
-        sysbench = sysbench_run.SysbenchRun(self.node1, debug)
+        sysbench = sysbench_run.SysbenchRun(self.node1, debug, workdir)
         sysbench.test_sanity_check(db)
         sysbench.test_sysbench_load(db, 10, 10, SYSBENCH_NORMAL_TABLE_SIZE)
 
@@ -58,7 +58,7 @@ for mysql_option in mysql_options:
         if os.path.exists(opt_dir):
             os.rmdir(opt_dir)
         os.mkdir(opt_dir)
-        shutil.copytree(WORKDIR + '/log', opt_dir)
+        shutil.copytree(workdir + '/log', opt_dir)
         continue
     random_mysql_option_qa.data_load()
     random_mysql_option_qa.shutdown_nodes()

--- a/suite/replication/backup_replication.py
+++ b/suite/replication/backup_replication.py
@@ -32,7 +32,7 @@ class SetupReplication(BaseTest):
 
     def sysbench_run(self, test_db):
         # Sysbench data load
-        sysbench = sysbench_run.SysbenchRun(self.node1, debug)
+        sysbench = sysbench_run.SysbenchRun(self.node1, debug, workdir)
 
         sysbench.test_sanity_check(test_db)
         sysbench.test_sysbench_load(test_db, SYSBENCH_TABLE_COUNT, SYSBENCH_THREADS, SYSBENCH_NORMAL_TABLE_SIZE)

--- a/suite/replication/gtid_replication.py
+++ b/suite/replication/gtid_replication.py
@@ -27,5 +27,5 @@ if __name__ == '__main__':
     if int(version) > int("050700"):
         utility.test_header("GTID PS1->PXC, PS2->PXC Multi source replication")
         gtid_replication_run.replication_testcase(2, comment='msr')
-        utility.test_header("GTID PS->PXC multi threaded async replication")
-        gtid_replication_run.replication_testcase(comment='mta')
+        utility.test_header("GTID PS->PXC single threaded async replication")
+        gtid_replication_run.replication_testcase(comment='sta')

--- a/suite/replication/replication.py
+++ b/suite/replication/replication.py
@@ -26,7 +26,7 @@ class SetupReplication(BaseTest):
     @staticmethod
     def sysbench_run(node: DbConnection, test_db):
         # Sysbench data load
-        sysbench = sysbench_run.SysbenchRun(node, debug)
+        sysbench = sysbench_run.SysbenchRun(node, debug, workdir)
 
         sysbench.test_sanity_check(test_db)
         sysbench.test_sysbench_load(test_db, SYSBENCH_TABLE_COUNT, SYSBENCH_THREADS, SYSBENCH_NORMAL_TABLE_SIZE)
@@ -53,11 +53,12 @@ class SetupReplication(BaseTest):
         my_extra = ""
         if int(version) < int("080400"):
             my_extra = "--master_info_repository=TABLE --relay_log_info_repository=TABLE"
-        if comment == "mta":
-            if int(version) > int("080300"):
-                my_extra = my_extra + ' --replica-parallel-workers=5'
-            else:
-                my_extra = my_extra + ' --slave-parallel-workers=5'
+        if comment == "sta":
+            if int(version) >= int("080027"):
+                my_extra = my_extra + ' --replica-parallel-workers=0'
+        else:
+            if int(version) < int("080027"):
+                my_extra = my_extra + ' --slave-parallel-workers=4'
 
         self.start_pxc(my_extra)
         number_of_nodes = self.get_number_of_nodes()
@@ -72,6 +73,10 @@ class SetupReplication(BaseTest):
             temp = source_node
             source_node = replica_node
             replica_node = temp
+        else:
+            for node in self.pxc_nodes:
+                node.execute("SET GLOBAL pxc_strict_mode = DISABLED")
+                utility_cmd.wait_for_wsrep_status(node)
 
         if comment == "msr":
             utility_cmd.invoke_replication(source_node, replica_node, self.rpl_type, 'channel1', version=version)
@@ -108,5 +113,5 @@ if __name__ == '__main__':
     if int(version) > int("050700"):
         utility.test_header("NON-GTID PS1->PXC, PS2->PXC Multi source replication")
         replication_run.replication_testcase(2, comment='msr')
-        utility.test_header("NON-GTID PS->PXC multi threaded async replication")
-        replication_run.replication_testcase(comment='mta')
+        utility.test_header("NON-GTID PS->PXC single threaded async replication")
+        replication_run.replication_testcase(comment='sta')

--- a/suite/ssl/encryption_qa.py
+++ b/suite/ssl/encryption_qa.py
@@ -25,7 +25,7 @@ class EncryptionTest(BaseTest):
             checksum = table_checksum.TableChecksum(self.node1, workdir, pt_basedir, debug)
             checksum.sanity_check(self.pxc_nodes)
 
-        sysbench = sysbench_run.SysbenchRun(self.node1, debug)
+        sysbench = sysbench_run.SysbenchRun(self.node1, debug, workdir)
         sysbench.test_sanity_check(db)
         sysbench.test_sysbench_load(db, SYSBENCH_TABLE_COUNT, SYSBENCH_THREADS, SYSBENCH_LOAD_TEST_TABLE_SIZE)
         sysbench.sysbench_ts_encryption(db, SYSBENCH_THREADS)
@@ -40,7 +40,7 @@ class EncryptionTest(BaseTest):
         for val1, val2, val3, val4, val5, val6 in \
                 itertools.product(option_values, repeat=6):
             # Start PXC cluster for encryption test
-            server_startup = pxc_startup.StartCluster(self.get_number_of_nodes(), debug)
+            server_startup = pxc_startup.StartCluster(self.get_number_of_nodes(), debug, worker_id=worker_id)
             server_startup.sanity_check()
 
             options = {"default_table_encryption": val1,
@@ -73,7 +73,6 @@ class EncryptionTest(BaseTest):
             if os.path.isfile(parent_dir + '/util/executesql.py'):
                 execute_sql = executesql.GenerateSQL(self.node1, db, 1000)
                 execute_sql.create_table()
-                sys.stdout = sys.__stdout__
 
             # Checksum for tables in test DB for 8.0.
             if int(version) >= int("080000"):

--- a/suite/ssl/ssl_qa.py
+++ b/suite/ssl/ssl_qa.py
@@ -19,7 +19,7 @@ class SSLCheck(BaseTest):
         super().__init__(ssl=True)
 
     def sysbench_run(self, test_db):
-        sysbench = sysbench_run.SysbenchRun(self.node1, debug)
+        sysbench = sysbench_run.SysbenchRun(self.node1, debug, workdir)
 
         sysbench.test_sanity_check(test_db)
         sysbench.test_sysbench_load(test_db, SYSBENCH_TABLE_COUNT, SYSBENCH_THREADS, SYSBENCH_NORMAL_TABLE_SIZE)

--- a/suite/sysbench_run/sysbench_customized_dataload_test.py
+++ b/suite/sysbench_run/sysbench_customized_dataload_test.py
@@ -25,7 +25,7 @@ class SysbenchLoadTest(BaseTest):
         if int(version) < int("080000"):
             checksum = table_checksum.TableChecksum(node, workdir, pt_basedir, debug)
             checksum.sanity_check(self.pxc_nodes)
-        sysbench = sysbench_run.SysbenchRun(node, debug)
+        sysbench = sysbench_run.SysbenchRun(node, debug, workdir)
         sysbench.test_sanity_check(db)
         sysbench.test_sysbench_custom_table(db)
 

--- a/suite/sysbench_run/sysbench_oltp_test.py
+++ b/suite/sysbench_run/sysbench_oltp_test.py
@@ -26,7 +26,7 @@ class SysbenchOLTPTest(BaseTest):
         if int(version) < int("080000"):
             checksum = table_checksum.TableChecksum(nodes[0], workdir, pt_basedir, debug)
             checksum.sanity_check(nodes)
-        sysbench = sysbench_run.SysbenchRun(nodes[0], debug)
+        sysbench = sysbench_run.SysbenchRun(nodes[0], debug, workdir)
         for thread in threads:
             sysbench.test_sanity_check(db)
             sysbench.sysbench_custom_oltp_load(db, 5, thread)

--- a/suite/sysbench_run/sysbench_read_only_test.py
+++ b/suite/sysbench_run/sysbench_read_only_test.py
@@ -26,7 +26,7 @@ class SysbenchReadOnlyTest(BaseTest):
         if int(version) < int("080000"):
             checksum = table_checksum.TableChecksum(nodes[0], workdir, pt_basedir, debug)
             checksum.sanity_check(nodes)
-        sysbench = sysbench_run.SysbenchRun(nodes[0], debug)
+        sysbench = sysbench_run.SysbenchRun(nodes[0], debug, workdir)
         for thread in threads:
             sysbench.test_sanity_check(db)
             sysbench.sysbench_custom_read_qa(db, 5, thread)

--- a/suite/upgrade/pxc_replication_upgrade.py
+++ b/suite/upgrade/pxc_replication_upgrade.py
@@ -25,7 +25,7 @@ class PXCUpgrade(BaseTest):
 
     def sysbench_run(self, db, upgrade_type: str):
         # Sysbench dataload for consistency test
-        sysbench_ps_node1 = sysbench_run.SysbenchRun(self.ps_nodes[0], debug)
+        sysbench_ps_node1 = sysbench_run.SysbenchRun(self.ps_nodes[0], debug, workdir)
 
         sysbench_ps_node1.test_sanity_check(db)
         sysbench_ps_node1.test_sysbench_load(db, SYSBENCH_TABLE_COUNT, SYSBENCH_THREADS, SYSBENCH_NORMAL_TABLE_SIZE)
@@ -33,9 +33,9 @@ class PXCUpgrade(BaseTest):
             if encryption:
                 for i in range(1, int(SYSBENCH_TABLE_COUNT) + 1):
                     self.ps_nodes[0].execute('alter table ' + db + '.sbtest' + str(i) + " encryption='Y'")
-        sysbench_node1 = sysbench_run.SysbenchRun(self.node1, debug)
-        sysbench_node2 = sysbench_run.SysbenchRun(self.node2, debug)
-        sysbench_node3 = sysbench_run.SysbenchRun(self.node3, debug)
+        sysbench_node1 = sysbench_run.SysbenchRun(self.node1, debug, workdir)
+        sysbench_node2 = sysbench_run.SysbenchRun(self.node2, debug, workdir)
+        sysbench_node3 = sysbench_run.SysbenchRun(self.node3, debug, workdir)
         if upgrade_type == 'readwrite':
             sysbench_node1.test_sysbench_oltp_read_write(db, SYSBENCH_TABLE_COUNT, SYSBENCH_THREADS,
                                                          SYSBENCH_NORMAL_TABLE_SIZE, 1000, True)
@@ -60,13 +60,13 @@ class PXCUpgrade(BaseTest):
         self.sysbench_run('sbtest', upgrade_type)
         time.sleep(10)
         for node in [self.node3, self.node2, self.node1]:
-            sysbench_pid = utility.sysbech_node_pid(node.get_node_number())
+            sysbench_pid = utility.sysbench_pid(node)
             utility_cmd.kill_process(sysbench_pid, "sysbench", True)
             pxc_startup.StartCluster.upgrade_pxc_node(node, debug)
         time.sleep(10)
         utility_cmd.replication_io_status(self.node3, high_version_num)
         utility_cmd.replication_sql_status(self.node3, high_version_num)
-        sysbench_node = sysbench_run.SysbenchRun(self.node1, debug)
+        sysbench_node = sysbench_run.SysbenchRun(self.node1, debug, workdir)
         sysbench_node.test_sysbench_oltp_read_write('sbtest', SYSBENCH_TABLE_COUNT, SYSBENCH_THREADS,
                                                     SYSBENCH_NORMAL_TABLE_SIZE, 100)
         time.sleep(15)

--- a/suite/upgrade/pxc_upgrade.py
+++ b/suite/upgrade/pxc_upgrade.py
@@ -18,11 +18,11 @@ class PXCUpgrade(BaseTest):
 
     def join_higher_version_node(self):
         # Start PXC cluster for upgrade test
-        self.pxc_nodes.append(pxc_startup.StartCluster.join_new_upgraded_node(self.node3, 4, debug))
+        self.pxc_nodes.append(pxc_startup.StartCluster.join_new_upgraded_node(self.node3, 4, debug, encryption=encryption))
 
     def sysbench_run(self, upgrade_type):
         # Sysbench dataload for consistency test
-        sysbench_node1 = sysbench_run.SysbenchRun(self.node1, debug)
+        sysbench_node1 = sysbench_run.SysbenchRun(self.node1, debug, workdir)
 
         sysbench_node1.test_sanity_check(db)
         sysbench_node1.test_sysbench_load(db, SYSBENCH_TABLE_COUNT, SYSBENCH_THREADS, SYSBENCH_NORMAL_TABLE_SIZE)
@@ -31,8 +31,8 @@ class PXCUpgrade(BaseTest):
                 for i in range(1, int(SYSBENCH_TABLE_COUNT) + 1):
                     self.node1.execute('alter table ' + db + '.sbtest' + str(i) + " encryption='Y'")
 
-        sysbench_node2 = sysbench_run.SysbenchRun(self.node2, debug)
-        sysbench_node3 = sysbench_run.SysbenchRun(self.node3, debug)
+        sysbench_node2 = sysbench_run.SysbenchRun(self.node2, debug, workdir)
+        sysbench_node3 = sysbench_run.SysbenchRun(self.node3, debug, workdir)
         if upgrade_type == 'readwrite' or upgrade_type == 'readwrite_sst':
             sysbench_node1.test_sysbench_oltp_read_write(db, SYSBENCH_TABLE_COUNT, SYSBENCH_THREADS,
                                                          SYSBENCH_NORMAL_TABLE_SIZE, 1000, True)
@@ -57,7 +57,7 @@ class PXCUpgrade(BaseTest):
         self.sysbench_run(upgrade_type)
         time.sleep(5)
         for node in [self.node3, self.node2, self.node1]:
-            sysbench_pid = utility.sysbech_node_pid(node.get_node_number())
+            sysbench_pid = utility.sysbench_pid(node)
             utility_cmd.kill_process(sysbench_pid, "sysbench run", True)
             if node == self.node3 and upgrade_type == 'readwrite_sst':
                 node_to_add_load = self.node1
@@ -69,7 +69,7 @@ class PXCUpgrade(BaseTest):
             else:
                 pxc_startup.StartCluster.upgrade_pxc_node(node, debug, node_to_add_load, cnf_replace)
         time.sleep(60)
-        sysbench_node = sysbench_run.SysbenchRun(self.node1, debug)
+        sysbench_node = sysbench_run.SysbenchRun(self.node1, debug, workdir)
         sysbench_node.test_sysbench_oltp_read_write(db, SYSBENCH_TABLE_COUNT, SYSBENCH_THREADS,
                                                     SYSBENCH_NORMAL_TABLE_SIZE, 100)
         time.sleep(5)

--- a/test/test_startup.py
+++ b/test/test_startup.py
@@ -5,34 +5,37 @@ from util import db_connection, pxc_startup
 config = configparser.ConfigParser()
 config.read('config.ini')
 config.sections()
-workdir = config['config']['workdir']
-basedir = config['config']['basedir']
 
 cluster = pxc_startup.StartCluster(3, 'YES')
-connection_check = db_connection.DbConnection(user='root', socket='/tmp/node1.sock')
-connection_check.connection_check()
-
+pxc_nodes = []
 
 class TestStartup(unittest.TestCase):
 
-    def test_sanity_check(self):
+    def test_01_sanity_check(self):
         self.assertEqual(cluster.sanity_check(), 0,
                          'work/base directory have some issues')
         print('PXC Sanity check')
 
-    def test_initialize_cluster(self):
+    def test_02_initialize_cluster(self):
+        cluster.create_config()
         self.assertIsNot(cluster.initialize_cluster(), 1,
                          'Could not initialize database directory. '
                          'Please check error log')
 
-    def test_start_cluster(self):
-        self.assertIsNot(cluster.start_cluster(), 1,
-                         'Could not start cluster, '
-                         'Please check error log')
+    def test_03_start_cluster(self):
+        global pxc_nodes
+        pxc_nodes = cluster.start_cluster()
+        if len(pxc_nodes) == 0:
+            self.fail('Could not start cluster, '
+                      'Please check error log')
         print('Started Cluster')
 
-    def test_connection_check(self):
-        self.assertIsNot(connection_check.connection_check(), 1,
+    def test_04_connection_check(self):
+        global pxc_nodes
+        if len(pxc_nodes) == 0:
+            self.skipTest('No nodes to check connection')
+        for node in pxc_nodes:
+            self.assertEqual(node.connection_check() , 0,
                          'Could not establish DB connection')
         print('Checked DB connection')
 

--- a/util/createsql.py
+++ b/util/createsql.py
@@ -30,9 +30,20 @@ class GenerateSQL:
         self.table_count = random.randint(1, len(table_names))
         self.column_count = random.randint(1, len(column_names))
         self.insert_sql_count = int(((self.lines / self.table_count) - 1))
-        
+        self._saved_stdout = None
+        self._out_file_handle = None
+
     def out_file(self):
-        sys.stdout = open(self.filename, "w")
+        self._saved_stdout = sys.stdout
+        self._out_file_handle = open(self.filename, "w")
+        sys.stdout = self._out_file_handle
+
+    def restore_stdout(self):
+        if self._out_file_handle is not None:
+            sys.stdout = self._saved_stdout
+            self._out_file_handle.close()
+            self._out_file_handle = None
+            self._saved_stdout = None
 
     def create_table(self):
         # Create table with random data.

--- a/util/data_generator.py
+++ b/util/data_generator.py
@@ -49,7 +49,9 @@ else:
 # Generate random data
 generate_sql = createsql.GenerateSQL(outfile, LINE_COUNT)
 generate_sql.out_file()
-generate_sql.create_table()
-generate_sql.drop_table()
-sys.stdout = sys.__stdout__
+try:
+    generate_sql.create_table()
+    generate_sql.drop_table()
+finally:
+    generate_sql.restore_stdout()
 print("DONE! Generated " + outfile)

--- a/util/db_connection.py
+++ b/util/db_connection.py
@@ -1,13 +1,33 @@
-import sys
 from datetime import datetime
 
 import mysql.connector
+from mysql.connector import errors as mysql_errors
 from _mysql_connector import MySQLInterfaceError
 
+CONNECTION_TIMEOUT = 60
+QUERY_TIMEOUT = 600
+
+# read_timeout/write_timeout and their exceptions require mysql-connector-python 9.2.0+.
+ReadTimeoutError = getattr(mysql_errors, 'ReadTimeoutError', None)
+WriteTimeoutError = getattr(mysql_errors, 'WriteTimeoutError', None)
+QUERY_TIMEOUT_SUPPORTED = ReadTimeoutError is not None and WriteTimeoutError is not None
+
+
+def _is_query_timeout(exc: BaseException) -> bool:
+    return QUERY_TIMEOUT_SUPPORTED and isinstance(exc, (ReadTimeoutError, WriteTimeoutError))
+
+
+class QueryExecutionError(Exception):
+    """Raised when a query fails.
+    """
+
+class QueryTimeoutError(Exception):
+    """Raised when a query exceeds QUERY_TIMEOUT.
+    """
 
 class DbConnection:
     def __init__(self, user, password=None, host='localhost', port=None, socket=None, node_num: int = 1, data_dir=None,
-                 conf_file=None, err_log=None, base_dir=None, startup_script=None, debug='No'):
+                 conf_file=None, err_log=None, base_dir=None, startup_script=None, debug='No', worker_id: int = 0):
         self.__user = user
         self.__socket = socket
         self.__data_dir = data_dir
@@ -20,13 +40,38 @@ class DbConnection:
         self.__host = host
         self.__port = port
         self.__password = password
+        self.__worker_id = worker_id
 
-    def connect(self):
+    def connect(self, query_timeout: int = QUERY_TIMEOUT):
+        connect_kwargs = {
+            'host': self.__host,
+            'user': self.__user,
+            'connection_timeout': CONNECTION_TIMEOUT,
+        }
+        if QUERY_TIMEOUT_SUPPORTED:
+            connect_kwargs['read_timeout'] = query_timeout
+            connect_kwargs['write_timeout'] = query_timeout
         if self.__socket is None:
-            return mysql.connector.connect(host=self.__host, port=self.__port, user=self.__user,
-                                           password=self.__password)
-        else:
-            return mysql.connector.connect(host=self.__host, unix_socket=self.__socket, user=self.__user)
+            connect_kwargs['port'] = self.__port
+            connect_kwargs['password'] = self.__password
+            return mysql.connector.connect(**connect_kwargs)
+        connect_kwargs['unix_socket'] = self.__socket
+        return mysql.connector.connect(**connect_kwargs)
+
+    def _execute(self, cursor, query, params=None):
+        try:
+            if params is None:
+                cursor.execute(query)
+            else:
+                cursor.execute(query, params)
+        except Exception as query_error:
+            if _is_query_timeout(query_error):
+                raise QueryTimeoutError(
+                    "Query timed out after " + str(query)
+                ) from query_error
+            raise QueryExecutionError(
+                "Error while executing query: " + str(query) + " :: " + str(query_error)
+            ) from query_error
 
     def connection_check(self, log_error_on_failure: bool = True):
         """ Method to test the cluster database connection.
@@ -67,7 +112,7 @@ class DbConnection:
             if self.__debug == 'YES' and log_query:
                 print(query)
             cursor = cnx.cursor()
-            cursor.execute(query)
+            self._execute(cursor, query)
             return cursor
         finally:
             # closing database connection.
@@ -87,7 +132,7 @@ class DbConnection:
             cnx = DbConnection.connect(self)
             cursor = cnx.cursor(buffered=True)
             for query in queries:
-                cursor.execute(query)
+                self._execute(cursor, query)
         finally:
             if cnx is not None and cnx.is_connected():
                 cnx.close()
@@ -97,17 +142,16 @@ class DbConnection:
         try:
             cnx = self.connect()
             cursor = cnx.cursor(buffered=True)
-            cursor.execute(query)
+            self._execute(cursor, query)
             row = cursor.fetchone()
             if self.__debug == 'YES':
                 print(row[0])
             return row[0]
-        except MySQLInterfaceError as mysqlInterfaceError:
-            if retries > 0:
+        except QueryExecutionError as query_error:
+            if isinstance(query_error.__cause__, MySQLInterfaceError) and retries > 0:
                 print("Retrying, left number of retries" + str(retries))
-                self.execute_get_value(query, int(retries - 1))
-            else:
-                raise Exception(str(mysqlInterfaceError))
+                return self.execute_get_value(query, int(retries - 1))
+            raise
         finally:
             # closing database connection.
             if cnx is not None and cnx.is_connected():
@@ -118,7 +162,7 @@ class DbConnection:
         try:
             cnx = self.connect()
             cursor = cnx.cursor(buffered=True)
-            cursor.execute(query)
+            self._execute(cursor, query)
             records = cursor.fetchall()
             print("Number of rows: ", cursor.rowcount)
             if self.__debug == 'YES':
@@ -134,7 +178,7 @@ class DbConnection:
         try:
             cnx = self.connect()
             cursor = cnx.cursor()
-            cursor.execute(query)
+            self._execute(cursor, query)
             records = cursor.fetchall()
             if self.__debug == 'YES':
                 print("Total number of rows in table: ", cursor.rowcount)
@@ -149,7 +193,7 @@ class DbConnection:
         try:
             cnx = self.connect()
             cursor = cnx.cursor(buffered=True, dictionary=True)
-            cursor.execute(query)
+            self._execute(cursor, query)
             row = cursor.fetchone()
             if self.__debug == 'YES':
                 print(row[column])
@@ -163,9 +207,12 @@ class DbConnection:
         try:
             cnx = self.connect()
             cursor = cnx.cursor()
-            cursor.execute("shutdown")
+            self._execute(cursor, "shutdown")
             print("Shutdown done Node" + str(self.__node_num))
             return 0
+        except QueryTimeoutError as query_timeout_error:
+            print("Timed out while shutting down node" + str(self.__node_num) + f": {query_timeout_error}")
+            raise
         except Exception as e:
             print("Error while connecting to MySQL/Shutting down", e)
             print(e)
@@ -175,19 +222,21 @@ class DbConnection:
             if cnx is not None and cnx.is_connected():
                 cnx.close()
 
-    def execute_query_from_file(self, file_path, multi=True):
+    def execute_query_from_file(self, file_path):
         cnx = None
         try:
             cnx = self.connect()
             cursor = cnx.cursor()
             with open(file_path, "r") as file:
                 sql_commands = file.read()
-                cursor.execute(sql_commands, multi=multi)
-            print("Execution of queries completed successfully.")
+                self._execute(cursor, sql_commands)
+            print("Execution of query from file completed successfully.")
+        except QueryTimeoutError as query_timeout_error:
+            print("Timed out while executing query from file" + file_path + f": {query_timeout_error}")
+            raise
         except Exception as e:
-            print("An error occurred while executing queries from file" + file_path + ": {}".format(e))
-            cnx.close()
-            sys.exit(1)
+            print("An error occurred while executing query from file" + file_path + ": {}".format(e))
+            raise
         finally:
             if cnx is not None and cnx.is_connected():
                 cnx.close()
@@ -206,10 +255,13 @@ class DbConnection:
             cursor = cnx.cursor(buffered=True)
             try:
                 if command.rstrip() != '':
-                    cursor.execute(command)
+                    self._execute(cursor, command)
             except ValueError as msg:
                 # Skip and report error
                 print("Command skipped: ", msg)
+            except QueryTimeoutError as query_timeout_error:
+                print("Timed out while executing query" + command + f": {query_timeout_error}")
+                raise
             except Exception as e:
                 print("Executing query ", command, "failed due to exception", str(e))
             finally:
@@ -218,23 +270,31 @@ class DbConnection:
         if self.__debug == 'YES':
             print("Execution of queries from the file ", file_path, "is done")
 
-    def call_proc(self, proc: str, args: list[str]):
+    def call_proc(self, proc: str, args: list[str], innodb_lock_wait_timeout: int = 0):
         cnx = None
         try:
-            cnx = self.connect()
+            cnx = self.connect(query_timeout=QUERY_TIMEOUT * 10)
             cursor = cnx.cursor()
+            if innodb_lock_wait_timeout > 0:
+                self._execute(cursor, "SET SESSION innodb_lock_wait_timeout = %s",
+                              (innodb_lock_wait_timeout,))
             cursor.callproc(proc, args=args)
             print("Execution of stored procedure call completed successfully.")
+        except QueryTimeoutError as query_timeout_error:
+            print("Timed out while executing stored procedure" + proc + f": {query_timeout_error}")
+            raise
         except Exception as e:
             print("An error occurred while executing stored procedure" + proc + ": {}".format(e))
-            cnx.close()
-            sys.exit(1)
+            raise
         finally:
             if cnx is not None and cnx.is_connected():
                 cnx.close()
 
     def get_port(self):
         return self.execute_get_value("select @@port")
+
+    def get_admin_port(self):
+        return self.execute_get_value("select @@admin_port")
 
     def get_mysql_version(self):
         return self.execute_get_value("select @@version")
@@ -262,3 +322,7 @@ class DbConnection:
 
     def get_node_number(self):
         return self.__node_num
+        
+    def get_worker_id(self):
+        return self.__worker_id
+

--- a/util/prepared_statements.sql
+++ b/util/prepared_statements.sql
@@ -29,7 +29,7 @@ CREATE PROCEDURE pstest.PS_INSERT() BEGIN
     WHILE create_start <= create_count DO
       SET @tbl = concat("tbl",create_start);
       WHILE insert_start <= insert_count DO
-        SELECT SUBSTRING(MD5(RAND()) FROM 1 FOR 50) INTO @str;
+        SELECT SUBSTRING(SHA2(CONCAT(RAND()), 256) FROM 1 FOR 50) INTO @str;
         SET @s = concat("INSERT INTO ",@tbl," (rtext) VALUES('",@str,"')");
         PREPARE stmt1 FROM @s;
         EXECUTE stmt1;
@@ -82,7 +82,7 @@ CREATE PROCEDURE pstest.PS_UPDATE()    BEGIN
     WHILE create_start <= create_count DO
       SET @tbl = concat("tbl",create_start);
       WHILE update_start <= update_count DO
-        SELECT SUBSTRING(MD5(RAND()) FROM 1 FOR 50) INTO @ustr;
+        SELECT SUBSTRING(SHA2(CONCAT(RAND()), 256) FROM 1 FOR 50) INTO @ustr;
         SET @s = concat("UPDATE ",@tbl ," SET rtext='",@ustr,"' ORDER BY RAND() LIMIT 1");
         PREPARE stmt1 FROM @s;
         EXECUTE stmt1;

--- a/util/ps_startup.py
+++ b/util/ps_startup.py
@@ -6,14 +6,13 @@
 import json
 import os
 import subprocess
-import random
 import shutil
 
 from config import WORKDIR, BASEDIR, PXC_LOWER_BASE, PXC_UPPER_BASE, USER
 from util import utility, db_connection
-from util.utility import Version, Utility
+from util.utility import Version, Utility, PS_PORT_SUB_BASE, NODE_PORT_STRIDE, worker_port_band_base, find_available_ports, launch_server
 
-workdir = WORKDIR
+global_workdir = WORKDIR
 base_dir = BASEDIR
 user = USER
 comp_name = 'component_keyring_file'
@@ -26,34 +25,6 @@ parent_dir = os.path.normpath(os.path.join(cwd, '../'))
 default_conf = parent_dir + '/conf/ps.cnf'
 default_custom_conf = parent_dir + '/conf/custom.cnf'
 default_encryption_conf = parent_dir + '/conf/encryption.cnf'
-workdir_custom_conf = workdir + '/conf/custom.cnf'
-workdir_encryption_conf = workdir + '/conf/encryption.cnf'
-
-
-def node_conf(i: int):
-    return workdir + '/conf/ps' + str(i) + '.cnf'
-
-
-def node_datadir(i: int):
-    return workdir + '/psnode' + str(i)
-
-
-def node_err_log(i: int):
-    return workdir + '/log/psnode' + str(i) + '.err'
-
-
-def node_socket(i: int):
-    return workdir + '/psnode' + str(i) + '/mysql.sock'
-
-
-def init_log(i: int):
-    return workdir + '/log/ps_init' + str(i) + '.log'
-
-
-def component_keyring_file_path(node_number: int):
-    keyring_dir = os.path.join(workdir, 'keyring')
-    os.makedirs(keyring_dir, exist_ok=True)
-    return os.path.join(keyring_dir, 'psnode' + str(node_number) + '_' + comp_name)
 
 
 def set_base_dir(server_version : Version):
@@ -64,14 +35,59 @@ def set_base_dir(server_version : Version):
     elif server_version == Version.HIGHER:
         base_dir = PXC_UPPER_BASE
 
+def ps_allocate_ports(worker_id, node_number):
+    base = worker_port_band_base(worker_id) + PS_PORT_SUB_BASE + (node_number - 1) * NODE_PORT_STRIDE
+    end = base + NODE_PORT_STRIDE - 1
+    try:
+        ports = find_available_ports(start=base, end=end, count=1)
+    except Exception as e:
+        if isinstance(e, ValueError):
+            raise
+        raise Exception(f"Failed to allocate PS node port for worker {worker_id}, node {node_number}: {e}") from e
+    return ports[0]
+
+def get_workdir(worker_id: int):
+    if worker_id > 0:
+        return global_workdir + '/w' + str(worker_id)
+    else:
+        return global_workdir
+
+def component_keyring_file_path(worker_id: int, node_number: int):
+    keyring_dir = os.path.join(get_workdir(worker_id), 'keyring')
+    os.makedirs(keyring_dir, exist_ok=True)
+    return os.path.join(keyring_dir, 'psnode' + str(node_number) + '_' + comp_name)
+
 
 class StartPerconaServer:
-    def __init__(self, number_of_nodes, debug, server_version: Version = None):
+    def __init__(self, number_of_nodes, debug, server_version: Version = None, worker_id: int = 0):
         self.__number_of_nodes = number_of_nodes
         self.__debug = debug
+        self.__worker_id = worker_id
+        self.__workdir = get_workdir(worker_id)
         if Version is not None:
             set_base_dir(server_version)
+        self.__workdir_custom_cnf = self.__workdir + '/conf/custom.cnf'
+        self.__workdir_encryption_cnf = self.__workdir + '/conf/encryption.cnf'
 
+    def node_conf(self, node_number: int):
+        return self.__workdir + '/conf/ps' + str(node_number) + '.cnf'
+
+
+    def node_datadir(self, node_number: int):
+        return self.__workdir + '/psnode' + str(node_number)
+
+
+    def node_err_log(self, node_number: int):
+        return self.__workdir + '/log/psnode' + str(node_number) + '.err'
+
+
+    def node_socket(self, node_number: int):
+        return self.__workdir + '/psnode' + str(node_number) + '/mysql.sock'
+
+
+    def init_log(self, node_number: int):
+        return self.__workdir + '/log/ps_init' + str(node_number) + '.log'
+    
     def test_sanity_check(self):
         """ Sanity check method will remove existing
             data directory and forcefully kill
@@ -79,31 +95,21 @@ class StartPerconaServer:
             the availability of mysqld binary file.
         """
         # kill existing mysqld process
-        os.system("ps -ef | grep '" + workdir + "/conf/ps[0-9].cnf'"
+        os.system("ps -ef | grep '" + self.__workdir + "/conf/ps[0-9].cnf'"
                                                 " | grep -v grep | awk '{print $2}' | xargs kill -9 >/dev/null 2>&1")
         result = 0
         # Create log directory
-        if not os.path.exists(workdir + '/log'):
-            os.mkdir(workdir + '/log')
+        if not os.path.exists(self.__workdir + '/log'):
+            os.mkdir(self.__workdir + '/log')
         # Create configuration directory
-        if not os.path.exists(workdir + '/conf'):
-            os.mkdir(workdir + '/conf')
+        if not os.path.exists(self.__workdir + '/conf'):
+            os.mkdir(self.__workdir + '/conf')
         # Check mysqld file
         if not os.path.isfile(base_dir + '/bin/mysqld'):
             print(base_dir + '/bin/mysqld does not exist')
             result = 1
         utility_cmd = utility.Utility(self.__debug)
         utility_cmd.check_testcase(result, "PS: Startup sanity check")
-
-    # This method will help us to check PS version
-    def version_check(self):
-        # Database version check
-        version_info = os.popen(base_dir + "/bin/mysqld --version 2>&1 | "
-                                           "grep -oe '[0-9]\.[0-9][\.0-9]*' | head -n1").read()
-        version = "{:02d}{:02d}{:02d}".format(int(version_info.split('.')[0]),
-                                              int(version_info.split('.')[1]),
-                                              int(version_info.split('.')[2]))
-        return version
 
     def create_config(self, conf_extra=None):
         """ Method to create cluster configuration file
@@ -113,34 +119,33 @@ class StartPerconaServer:
             in conf/custom.conf.
         """
         version = Utility.version_check(base_dir)  # Get server version
-        port = random.randint(21, 30) * 1004
         port_list = []
         result = 0
         for j in range(1, self.__number_of_nodes + 1):
-            port_list += [port + (j * 100)]
+            port_list.append(ps_allocate_ports(self.__worker_id, j))
         if not os.path.isfile(default_conf):
             print('Default pxc.cnf is missing ' + default_conf)
             result = 1
         else:
-            shutil.copy(default_custom_conf, workdir_custom_conf)
+            shutil.copy(default_custom_conf, self.__workdir_custom_cnf)
         # Add custom mysqld options in configuration file
         for i in range(1, self.__number_of_nodes + 1):
-            conf = node_conf(i)
+            conf = self.node_conf(i)
             shutil.copy(default_conf, conf)
             cnf_name = open(conf, 'a+')
             cnf_name.write('\nport=' + str(port_list[i - 1]) + '\n')
             if int(version) > int("050700"):
                 cnf_name.write('log_error_verbosity=3\n')
-            cnf_name.write('socket=' + node_socket(i) + '\n')
-            cnf_name.write('server_id=' + str(100 + i) + '\n')
-            cnf_name.write('!include ' + workdir_custom_conf + '\n')
+            cnf_name.write('socket=' + self.node_socket(i) + '\n')
+            cnf_name.write('server_id=' + str(100 + self.__worker_id + i) + '\n')
+            cnf_name.write('!include ' + self.__workdir_custom_cnf + '\n')
             if conf_extra == 'encryption':
-                shutil.copy(default_encryption_conf, workdir_encryption_conf)
+                shutil.copy(default_encryption_conf, self.__workdir_encryption_cnf)
                 if int(version) < int("080024"):
-                    with open(workdir_encryption_conf, 'a+') as cnf_file:
+                    with open(self.__workdir_encryption_cnf, 'a+') as cnf_file:
                         cnf_file.write('early-plugin-load = keyring_file.so\n')
                         cnf_file.write('keyring_file_data = keyring\n')
-                cnf_name.write('!include ' + workdir_encryption_conf + '\n')
+                cnf_name.write('!include ' + self.__workdir_encryption_cnf + '\n')
             cnf_name.close()
 
         utility_cmd = utility.Utility(self.__debug)
@@ -156,7 +161,7 @@ class StartPerconaServer:
             result = 1
         # Add custom configurations
         config_file = config_file
-        cnf_name = open(workdir_custom_conf, 'a+')
+        cnf_name = open(self.__workdir_custom_cnf, 'a+')
         cnf_name.write('\n')
         cnf_name.write('!include ' + config_file + '\n')
         cnf_name.close()
@@ -171,15 +176,16 @@ class StartPerconaServer:
         """
         result = 1  # return value
         for i in range(1, self.__number_of_nodes + 1):
-            conf = node_conf(i)
-            datadir = node_datadir(i)
+            conf = self.node_conf(i)
+            datadir = self.node_datadir(i)
+            err_log = self.node_err_log(i)
             if os.path.exists(datadir):
                 os.system('rm -rf ' + datadir + ' >/dev/null 2>&1')
             if not os.path.isfile(conf):
                 print('Could not find config file ' + conf)
                 exit(1)
-            version = self.version_check()  # Get server version
-            initialize_log = init_log(i)
+            version = Utility.version_check(base_dir)  # Get server version
+            initialize_log = self.init_log(i)
             # Initialize data directory
             if int(version) < int("050700"):
                 os.mkdir(datadir)
@@ -199,7 +205,7 @@ class StartPerconaServer:
                         manifest_file.write('\n')
 
                     with open(os.path.join(datadir, comp_name + '.cnf'), 'w') as cnf_file:
-                        json.dump({"path": component_keyring_file_path(i), "read_only": False}, cnf_file, indent=2)
+                        json.dump({"path": component_keyring_file_path(self.__worker_id, i), "read_only": False}, cnf_file, indent=2)
                         cnf_file.write('\n')
 
         utility_cmd = utility.Utility(self.__debug)
@@ -213,20 +219,23 @@ class StartPerconaServer:
             my_extra = ''
         ps_nodes = []
         for i in range(1, self.__number_of_nodes + 1):
-            socket = node_socket(i)
-            conf = node_conf(i)
-            err_log = node_err_log(i)
+            socket = self.node_socket(i)
+            conf = self.node_conf(i)
+            err_log = self.node_err_log(i)
             mysqld = base_dir + '/bin/mysqld'
-            datadir = node_datadir(i)
+            datadir = self.node_datadir(i)
             # Start server
             startup = (mysqld + ' --defaults-file=' + conf + ' --datadir=' + datadir + ' --basedir=' + base_dir +
-                       ' ' + my_extra + ' --log-error=' + err_log + ' > ' + err_log + ' 2>&1 &')
+                       ' ' + my_extra + ' --log-error=' + err_log + ' > ' + err_log + ' 2>&1')
             if self.__debug == 'YES':
                 print(startup)
-            subprocess.call(startup, shell=True, stderr=subprocess.DEVNULL)
+            launch_result = launch_server(startup)
+            if launch_result != 0:
+                print("Server " + str(i) + " startup failed on launch with exit code " + str(launch_result))
+                break
             utility_cmd = utility.Utility(self.__debug)
             node = db_connection.DbConnection(user=user, socket=socket, node_num=i, data_dir=datadir, conf_file=conf,
-                                              err_log=err_log, base_dir=base_dir, debug=self.__debug)
+                                              err_log=err_log, base_dir=base_dir, debug=self.__debug, worker_id=self.__worker_id)
             if verify_startup:
                 utility_cmd.startup_check(node)
             ps_nodes.append(node)

--- a/util/pxc_startup.py
+++ b/util/pxc_startup.py
@@ -7,36 +7,58 @@ from gzip import BadGzipFile
 import json
 import os
 import subprocess
-import random
 import shutil
 import time
+
 from distutils.spawn import find_executable
 
 from util import sanity, utility, sysbench_run
 from util import db_connection
 from config import *
 from util.db_connection import DbConnection
-from util.utility import Version, Utility
+from util.utility import (Version, Utility, NODE_PORT_STRIDE, worker_port_band_base, find_available_ports,
+                          launch_server)
 
-workdir = WORKDIR
+global_workdir = WORKDIR
 base_dir = BASEDIR
 user = USER
 comp_name = 'component_keyring_file'
+cluster_keyring_file_name = 'cluster_' + comp_name
+node_keyring_file_name = 'node_' + '{node_number}' + '_' + comp_name
+ps_node_keyring_file_name = 'psnode' + '{node_number}' + '_' + comp_name
 
 higher_version_basedir = PXC_UPPER_BASE
 lower_base_dir = PXC_LOWER_BASE
 DEFAULT_SERVER_UP_TIMEOUT = 300
-backup_dir = workdir + "/backup"
 
 cwd = os.path.dirname(os.path.realpath(__file__))
 parent_dir = os.path.normpath(os.path.join(cwd, '../'))
 
-default_pxc_cnf = parent_dir + '/conf/pxc.cnf'
-default_custom_cnf = parent_dir + '/conf/custom.cnf'
-encryption_cnf = parent_dir + '/conf/encryption.cnf'
-workdir_custom_cnf = workdir + '/conf/custom.cnf'
-workdir_encryption_cnf = workdir + '/conf/encryption.cnf'
+default_pxc_cnf = os.path.join(parent_dir, 'conf', 'pxc.cnf')
+default_custom_cnf = os.path.join(parent_dir, 'conf', 'custom.cnf')
+encryption_cnf = os.path.join(parent_dir, 'conf', 'encryption.cnf')
 
+BACKUP_TIMEOUT = 1800
+
+
+def pxc_allocate_ports(worker_id, node_number, set_admin_address: bool = False):
+    slot_base = (worker_port_band_base(worker_id) + (node_number - 1) * NODE_PORT_STRIDE)
+    slot_end = slot_base + NODE_PORT_STRIDE - 1
+
+    if set_admin_address:
+        count = 5
+    else:
+        count = 4
+
+    try:
+        ports = find_available_ports(start=slot_base, end=slot_end, count=count)
+    except Exception as e:
+        if isinstance(e, ValueError):
+            raise
+        raise Exception(f"Failed to allocate PXC ports for worker {worker_id}, node {node_number}: {e}") from e
+    if set_admin_address:
+        return ports[0], ports[1], ports[2], ports[3], ports[4]
+    return ports[0], ports[1], ports[2], ports[3]
 
 def set_base_dir(server_version: Version):
     global base_dir
@@ -46,48 +68,49 @@ def set_base_dir(server_version: Version):
     elif server_version == Version.HIGHER:
         base_dir = PXC_UPPER_BASE
 
+def get_workdir(worker_id: int):
+    if worker_id > 0:
+        return global_workdir + '/w' + str(worker_id)
+    else:
+        return global_workdir
 
-def node_conf(node_number: int):
-    return workdir + '/conf/node' + str(node_number) + '.cnf'
+def node_conf(worker_id: int, node_number: int):
+    return os.path.join(get_workdir(worker_id), 'conf', 'node' + str(node_number) + '.cnf')
 
+def node_datadir(worker_id: int, node_number: int):
+    return os.path.join(get_workdir(worker_id), 'node' + str(node_number))
 
-def node_socket(node_number: int):
-    return workdir + '/node' + str(node_number) + '/mysql.sock'
+def node_startup_script(worker_id: int, node_number: int):
+    return os.path.join(get_workdir(worker_id), 'log', 'startup' + str(node_number) + '.sh')
 
+def node_socket(worker_id: int, node_number: int):
+    return os.path.join(get_workdir(worker_id), 'node' + str(node_number), 'mysql.sock')
 
-def node_err_log(node_number: int):
-    return workdir + '/log/node' + str(node_number) + '.err'
+def node_err_log(worker_id: int, node_number: int):
+    return os.path.join(get_workdir(worker_id), 'log', 'node' + str(node_number) + '.err')
 
+def get_backup_dir(worker_id: int):
+    return os.path.join(get_workdir(worker_id), 'backup')
 
-def node_datadir(node_number: int):
-    return workdir + '/node' + str(node_number)
+def get_keyring_dir(worker_id: int):
+    return os.path.join(get_workdir(worker_id), 'keyring')
 
-
-def node_startup_script(node_number: int):
-    return workdir + '/log/startup' + str(node_number) + '.sh'
-
-
-def init_log(node_number: int):
-    return workdir + '/log/init' + str(node_number) + '.log'
-
-
-def component_keyring_file_path(node_number: int):
-    keyring_dir = os.path.join(workdir, 'keyring')
+def component_keyring_file_path(worker_id: int, node_number: int):
+    keyring_dir = get_keyring_dir(worker_id)
     os.makedirs(keyring_dir, exist_ok=True)
-    return os.path.join(keyring_dir, 'node' + str(node_number) + '_' + comp_name)
+    return os.path.join(keyring_dir, node_keyring_file_name.format(node_number=node_number))
 
-
-def cluster_keyring_file_path():
-    keyring_dir = os.path.join(workdir, 'keyring')
+def cluster_keyring_file_path(worker_id: int):
+    keyring_dir = get_keyring_dir(worker_id)
     os.makedirs(keyring_dir, exist_ok=True)
-    return os.path.join(keyring_dir, 'cluster_' + comp_name)
+    return os.path.join(keyring_dir, cluster_keyring_file_name)
 
-def setup_global_keyring():
+def setup_global_keyring(worker_id: int):
     with open(os.path.join(base_dir, 'bin', 'mysqld.my'), 'w') as manifest_file:
         json.dump({"components": "file://" + comp_name}, manifest_file, indent=2)
         manifest_file.write('\n')
     with open(os.path.join(base_dir, 'lib', 'plugin', comp_name + '.cnf'), 'w') as cnf_file:
-        json.dump({"path": cluster_keyring_file_path(), "read_only": False}, cnf_file, indent=2)
+        json.dump({"path": cluster_keyring_file_path(worker_id), "read_only": False}, cnf_file, indent=2)
         cnf_file.write('\n')
 
 def setup_local_keyring_redirect():
@@ -99,33 +122,42 @@ def setup_local_keyring_redirect():
         json.dump({"read_local_config": True}, cnf_file, indent=2)
         cnf_file.write('\n')
 
-def setup_local_keyring(node_number: int):
-    with open(os.path.join(node_datadir(node_number), 'mysqld.my'), 'w') as manifest_file:
+def setup_local_keyring(worker_id: int, node_number: int):
+    with open(os.path.join(node_datadir(worker_id, node_number), 'mysqld.my'), 'w') as manifest_file:
         json.dump({"components": "file://" + comp_name}, manifest_file, indent=2)
         manifest_file.write('\n')
 
-    with open(os.path.join(node_datadir(node_number), comp_name + '.cnf'), 'w') as cnf_file:
-        json.dump({"path": component_keyring_file_path(node_number), "read_only": False}, cnf_file, indent=2)
+    with open(os.path.join(node_datadir(worker_id, node_number), comp_name + '.cnf'), 'w') as cnf_file:
+        json.dump({"path": component_keyring_file_path(worker_id, node_number), "read_only": False}, cnf_file, indent=2)
         cnf_file.write('\n')
-
-def add_conf(option_values: dict):
-    cnf_name = open(workdir_custom_cnf, 'a+')
-    for opt in option_values:
-        cnf_name.write(opt + '=' + option_values[opt] + '\n')
-    cnf_name.close()
 
 
 class StartCluster:
-    def __init__(self, number_of_nodes, debug, server_version: Version = None):
+    def __init__(self, number_of_nodes, debug, server_version: Version = None, worker_id: int = 0):
         self.__number_of_nodes = int(number_of_nodes)
         self.__debug = debug
+        self.__worker_id = worker_id
+        self.__workdir = get_workdir(worker_id)
+        if not os.path.exists( self.__workdir):
+            os.mkdir(self.__workdir)
         if Version is not None:
             set_base_dir(server_version)
+        self.__workdir_custom_cnf = os.path.join(self.__workdir, 'conf', 'custom.cnf')
+        self.__workdir_encryption_cnf = os.path.join(self.__workdir, 'conf', 'encryption.cnf')
 
-    @staticmethod
-    def kill_mysqld():
+    def init_log(self, node_number: int):
+        return os.path.join(self.__workdir, 'log', 'init' + str(node_number) + '.log')
+
+
+    def add_conf(self, option_values: dict):
+        cnf_name = open(self.__workdir_custom_cnf, 'a+')
+        for opt in option_values:
+            cnf_name.write(opt + '=' + option_values[opt] + '\n')
+        cnf_name.close()
+
+    def kill_mysqld(self):
         # kill existing mysqld process
-        os.system("ps -ef | grep '" + workdir + "/conf/node[0-9].cnf' | grep -v grep | "
+        os.system("ps -ef | grep '" + os.path.join(self.__workdir, 'conf', 'node[0-9].cnf') + "' | grep -v grep | "
                                                 "awk '{print $2}' | xargs kill -9 >/dev/null 2>&1")
 
     def sanity_check(self):
@@ -138,14 +170,14 @@ class StartCluster:
         # kill existing mysqld process
         self.kill_mysqld()
 
-        if not os.path.exists(workdir + '/log'):
-            os.mkdir(workdir + '/log')
+        if not os.path.exists( os.path.join(self.__workdir, 'log')):
+            os.mkdir( os.path.join(self.__workdir, 'log'))
 
-        if not os.path.exists(workdir + '/conf'):
-            os.mkdir(workdir + '/conf')
+        if not os.path.exists( os.path.join(self.__workdir, 'conf')):
+            os.mkdir( os.path.join(self.__workdir, 'conf'))
 
-        if not os.path.isfile(base_dir + '/bin/mysqld'):
-            print(base_dir + '/bin/mysqld does not exist')
+        if not os.path.isfile(os.path.join(base_dir, 'bin', 'mysqld')):
+            print(os.path.join(base_dir, 'bin', 'mysqld') + ' does not exist')
             result = 1
         utility_cmd = utility.Utility(self.__debug)
         utility_cmd.check_testcase(result, "Startup sanity check")
@@ -161,28 +193,30 @@ class StartCluster:
         if wsrep_provider_option is None:
             wsrep_provider_option = ''
         version = Utility.version_check(base_dir)
-        port = random.randint(10, 19) * 1000
-        port_list = []
+        port_allocations = []
         addr_list = ''
         result = 0
         for j in range(1, self.__number_of_nodes + 1):
-            port_list += [port + (j * 100)]
-            addr_list = addr_list + '127.0.0.1:' + str(port + (j * 100) + 8) + ','
+            ports = pxc_allocate_ports(self.__worker_id, j, set_admin_address)
+            port_allocations.append(ports)
+            addr_list = addr_list + '127.0.0.1:' + str(ports[1]) + ','
         if not os.path.isfile(default_pxc_cnf):
             print('Default pxc.cnf is missing in ' + default_pxc_cnf)
             result = 1
         else:
-            shutil.copy(default_custom_cnf, workdir_custom_cnf)
+            shutil.copy(default_custom_cnf, self.__workdir_custom_cnf)
         if wsrep_extra == 'encryption' and default_encryption_conf:
-            shutil.copy(encryption_cnf, workdir_encryption_cnf)
+            shutil.copy(encryption_cnf, self.__workdir_encryption_cnf)
             if int(version) < int("080024"):
-                with open(workdir_encryption_cnf, 'a+') as cnf_file:
+                with open(self.__workdir_encryption_cnf, 'a+') as cnf_file:
                     cnf_file.write('early-plugin-load = keyring_file.so\n')
                     cnf_file.write('keyring_file_data = keyring\n')
         for i in range(1, self.__number_of_nodes + 1):
-            cnf = node_conf(i)
+            cnf = node_conf(self.__worker_id, i)
             shutil.copy(default_pxc_cnf, cnf)
             cnf_name = open(cnf, 'a+')
+            if self.__worker_id > 0:
+                cnf_name.write('innodb_use_native_aio=0\n')
             if self.__debug == 'YES':
                 cnf_name.write('wsrep-debug=1\n')
             cnf_name.write('wsrep_cluster_address=gcomm://' + addr_list + '\n')
@@ -193,33 +227,43 @@ class StartCluster:
                 cnf_name.write('wsrep_sst_auth=root:\n')
             if int(version) > int("050700"):
                 cnf_name.write('log_error_verbosity=3\n')
-            cnf_name.write('port=' + str(port_list[i - 1]) + '\n')
+            mysql_port, galera_port, ist_port, sst_port = port_allocations[i - 1][:4]
+            if set_admin_address:
+                admin_port = port_allocations[i - 1][4]
+            else:
+                admin_port = None
+            cnf_name.write('port=' + str(mysql_port) + '\n')
+            cnf_name.write('wsrep_sst_receive_address=127.0.0.1:' + str(sst_port) + '\n')
             if wsrep_extra == "ssl" or wsrep_extra == "encryption":
                 cnf_name.write("wsrep_provider_options='gmcast.listen_addr=tcp://127.0.0.1:"
-                               + str(port_list[i - 1] + 8) + ';' + wsrep_provider_option + 'socket.ssl_key='
-                               + workdir + '/cert/server-key.pem;socket.ssl_cert='
-                               + workdir + '/cert/server-cert.pem;socket.ssl_ca='
-                               + workdir + "/cert/ca.pem'\n")
-                cnf_name.write('!include ' + workdir + '/conf/ssl.cnf\n')
-                sanity.create_ssl_certificate(workdir)
+                               + str(galera_port) + ';ist.recv_addr=127.0.0.1:' + str(ist_port) + ';'
+                               + wsrep_provider_option + 'socket.ssl_key='
+                               + self.__workdir + '/cert/server-key.pem;socket.ssl_cert='
+                               + self.__workdir + '/cert/server-cert.pem;socket.ssl_ca='
+                               + self.__workdir + "/cert/ca.pem'\n")
+                cnf_name.write('!include ' + self.__workdir + '/conf/ssl.cnf\n')
+                sanity.create_ssl_certificate(self.__workdir)
             else:
                 cnf_name.write("wsrep_provider_options='gmcast.listen_addr=tcp://127.0.0.1:"
-                               + str(port_list[i - 1] + 8) + ';' + wsrep_provider_option + "'\n")
-            cnf_name.write('socket=' + node_socket(i) + '\n')
+                               + str(galera_port) + ';ist.recv_addr=127.0.0.1:' + str(ist_port) + ';'
+                               + wsrep_provider_option + "'\n")
+            cnf_name.write('socket=' + node_socket(self.__worker_id, i) + '\n')
             cnf_name.write('server_id=' + str(10 + i) + '\n')
-            cnf_name.write('!include ' + workdir_custom_cnf + '\n')
+            cnf_name.write('!include ' + self.__workdir_custom_cnf + '\n')
             if default_encryption_conf:
                 if wsrep_extra == 'encryption':
-                    cnf_name.write('!include ' + workdir_encryption_cnf + '\n')
+                    cnf_name.write('!include ' + self.__workdir_encryption_cnf + '\n')
                     cnf_name.write('pxc_encrypt_cluster_traffic = ON\n')
                 elif int(version) > int("050700"):
                     cnf_name.write('pxc_encrypt_cluster_traffic = OFF\n')
-            if set_admin_address:
+            if admin_port is not None:
                 cnf_name.write('admin_address=127.0.0.1\n')
-                cnf_name.write('admin_port=' + str(33062 + i) + '\n')
+                cnf_name.write('admin_port=' + str(admin_port) + '\n')
+            if self.__worker_id > 0:
+                cnf_name.write('[sst]\ndonor_timeout_wait_joiner=400\n')
             cnf_name.close()
         if custom_conf_settings is not None:
-            add_conf(custom_conf_settings)
+            self.add_conf(custom_conf_settings)
         utility_cmd = utility.Utility(self.__debug)
         utility_cmd.check_testcase(result, "Configuration file creation")
 
@@ -232,7 +276,7 @@ class StartCluster:
             print('Custom config ' + config_file + ' is missing')
             result = 1
         config_file = config_file
-        cnf_name = open(workdir_custom_cnf, 'a+')
+        cnf_name = open(self.__workdir_custom_cnf, 'a+')
         cnf_name.write('\n')
         cnf_name.write('!include ' + config_file + '\n')
         cnf_name.close()
@@ -260,15 +304,14 @@ class StartCluster:
                 if int(version) < int("080024"):
                     init_extra = init_extra + " --early-plugin-load=keyring_file.so --keyring_file_data=keyring"
                 else:
-                    setup_global_keyring()
+                    setup_global_keyring(self.__worker_id)
             elif int(version) >= int("080024"):
                 setup_local_keyring_redirect()
 
         for i in range(1, self.__number_of_nodes + 1):
-            conf = node_conf(i)
-            datadir = node_datadir(i)
-            initialize_log = init_log(i)
-
+            conf = node_conf(self.__worker_id, i)
+            datadir = node_datadir(self.__worker_id, i)
+            initialize_log = self.init_log(i)
             if os.path.exists(datadir):
                 os.system('rm -rf ' + datadir + '>/dev/null 2>&1')
             if not os.path.isfile(conf):
@@ -288,7 +331,7 @@ class StartCluster:
             result = ("{}".format(run_query))
             if encryption and not sys_table_encrypt:
                 if int(version) >= int("080024"):
-                    setup_local_keyring(i)
+                    setup_local_keyring(self.__worker_id, i)
 
         utility_cmd = utility.Utility(self.__debug)
         utility_cmd.check_testcase(int(result), "Initializing cluster")
@@ -302,12 +345,12 @@ class StartCluster:
             my_extra = ''
         pxc_nodes = []
         for i in range(1, self.__number_of_nodes + 1):
-            socket = node_socket(i)
-            conf = node_conf(i)
-            err_log = node_err_log(i)
+            socket = node_socket(self.__worker_id, i)
+            conf = node_conf(self.__worker_id, i)
+            err_log = node_err_log(self.__worker_id, i)
             mysqld = base_dir + '/bin/mysqld'
-            datadir = node_datadir(i)
-            startup_script = node_startup_script(i)
+            datadir = node_datadir(self.__worker_id, i)
+            startup_script = node_startup_script(self.__worker_id, i)
 
             startup = (mysqld + ' --defaults-file=' + conf +
                        ' --datadir=' + datadir +
@@ -315,17 +358,21 @@ class StartCluster:
                        ' --wsrep-provider=' + base_dir + '/lib/libgalera_smm.so')
             if i == 1:
                 startup = startup + ' --wsrep-new-cluster'
-            startup = startup + ' --log-error=' + err_log + ' > ' + err_log + ' 2>&1 &'
+            startup = startup + ' --log-error=' + err_log + ' > ' + err_log + ' 2>&1'
 
             save_startup = 'echo "' + startup + '" > ' + startup_script
             os.system(save_startup)
             if self.__debug == 'YES':
                 print(startup)
-            subprocess.call(startup, shell=True, stderr=subprocess.DEVNULL)
+            launch_result = launch_server(startup)
+            if launch_result != 0:
+                print("Node" + str(i) + " startup failed on launch with exit code " + str(launch_result))
+                result = -2
+                break
             utility_cmd = utility.Utility(self.__debug)
             node = db_connection.DbConnection(user=user, socket=socket, node_num=i, data_dir=datadir, conf_file=conf,
                                               err_log=err_log, base_dir=base_dir, startup_script=startup_script,
-                                              debug=self.__debug)
+                                              debug=self.__debug, worker_id=self.__worker_id)
             result = utility_cmd.startup_check(node, terminate_on_startup_failure)
             pxc_nodes.append(node)
         if result != 0:
@@ -334,16 +381,16 @@ class StartCluster:
 
     @staticmethod
     def join_new_node(donor: DbConnection, joiner_node_number: int, basedir: str = base_dir, debug: str = 'NO', encryption: bool = False):
-        joiner_node_cnf = node_conf(joiner_node_number)
-        startup_script = node_startup_script(joiner_node_number)
-        joiner_data_dir = node_datadir(joiner_node_number)
+        worker_id = donor.get_worker_id()   
+        joiner_node_cnf = node_conf(worker_id, joiner_node_number)
+        startup_script = node_startup_script(worker_id, joiner_node_number)
+        joiner_data_dir = node_datadir(worker_id, joiner_node_number)
         donor_node_num = donor.get_node_number()
         shutil.copy(donor.get_conf_file(), joiner_node_cnf)
         wsrep_cluster_addr = donor.execute_get_row("show variables like 'wsrep_cluster_address'")[1]
-        port_no = donor.get_port()
 
-        port_no = int(port_no) + 100
-        wsrep_port_no = int(port_no) + 8
+        port_no, wsrep_port_no, ist_port_no, sst_port_no = pxc_allocate_ports(
+            worker_id, joiner_node_number)
         os.system("sed -i 's#node" + str(donor_node_num) + "#node" + str(joiner_node_number) + "#g' " + joiner_node_cnf)
         os.system("sed -i '/wsrep_sst_auth=root:/d' " + joiner_node_cnf)
         os.system("sed -i  '0,/^[ \\t]*wsrep_cluster_address[ \\t]*=.*$/s|"
@@ -353,16 +400,27 @@ class StartCluster:
         os.system("sed -i  '0,/^[ \\t]*port[ \\t]*=.*$/s|"
                   "^[ \\t]*port[ \\t]*=.*$|port="
                   + str(port_no) + "|' " + joiner_node_cnf)
-        os.system('sed -i  "0,/^[ \\t]*wsrep_provider_options[ \\t]*=.*$/s|'
-                  "^[ \\t]*wsrep_provider_options[ \\t]*=.*$|wsrep_provider_options="
-                  "'gmcast.listen_addr=tcp://127.0.0.1:" + str(wsrep_port_no) +
-                  "'|\" " + joiner_node_cnf)
+        os.system(
+            f"sed -i '/^[ \\t]*wsrep_provider_options/s#"
+            f"gmcast\\.listen_addr=tcp://127\\.0\\.0\\.1:[0-9][0-9]*#"
+            f"gmcast.listen_addr=tcp://127.0.0.1:{wsrep_port_no}#' "
+            f"{joiner_node_cnf}"
+        )
+        os.system(
+            f"sed -i '/^[ \\t]*wsrep_provider_options/s#"
+            f"ist\\.recv_addr=127\\.0\\.0\\.1:[0-9][0-9]*#"
+            f"ist.recv_addr=127.0.0.1:{ist_port_no}#' "
+            f"{joiner_node_cnf}"
+        )
+        os.system("sed -i  '0,/^[ \\t]*wsrep_sst_receive_address[ \\t]*=.*$/s|"
+                  "^[ \\t]*wsrep_sst_receive_address[ \\t]*=.*$|wsrep_sst_receive_address=127.0.0.1:"
+                  + str(sst_port_no) + "|' " + joiner_node_cnf)
         os.system("sed -i  '0,/^[ \\t]*server_id[ \\t]*=.*$/s|"
                   "^[ \\t]*server_id[ \\t]*=.*$|server_id="
                   "14|' " + joiner_node_cnf)
 
         create_upgrade_startup = (
-                'sed  "s#' + lower_base_dir + '#' + basedir + '#g" ' + node_startup_script(donor_node_num) +
+                'sed  "s#' + lower_base_dir + '#' + basedir + '#g" ' + donor.get_startup_script() +
                 ' > ' + startup_script)
         if debug == 'YES':
             print(create_upgrade_startup)
@@ -372,13 +430,13 @@ class StartCluster:
         os.system("rm -rf " + joiner_data_dir)
         os.mkdir(joiner_data_dir)
         if encryption:
-            setup_local_keyring(joiner_node_number)
+            setup_local_keyring(worker_id, joiner_node_number)
 
         time.sleep(10)
-        joiner = db_connection.DbConnection(user=user, socket=node_socket(joiner_node_number),
+        joiner = db_connection.DbConnection(user=user, socket=node_socket(worker_id, joiner_node_number),
                                             node_num=joiner_node_number, data_dir=joiner_data_dir,
-                                            conf_file=joiner_node_cnf, err_log=node_err_log(joiner_node_number),
-                                            base_dir=base_dir, startup_script=startup_script, debug=debug)
+                                            conf_file=joiner_node_cnf, err_log=node_err_log(worker_id, joiner_node_number),
+                                            base_dir=base_dir, startup_script=startup_script, debug=debug, worker_id=worker_id)
         utility_cmd = utility.Utility(debug)
         utility_cmd.restart_cluster_node(joiner)
         utility_cmd.startup_check(joiner)
@@ -397,7 +455,8 @@ class StartCluster:
         time.sleep(60)
 
         if node_to_add_load is not None:
-            sysbench = sysbench_run.SysbenchRun(node_to_add_load, debug)
+            sysbench = sysbench_run.SysbenchRun(node_to_add_load, debug,
+                                                get_workdir(node_to_add_load.get_worker_id()))
             sysbench.sanity_check('test_one')
             sysbench.sanity_check('test_two')
             sysbench.sanity_check('test_three')
@@ -419,16 +478,21 @@ class StartCluster:
             startup_cmd = (higher_version_basedir + '/bin/mysqld --defaults-file=' + node.get_conf_file() +
                            ' --wsrep-provider=' + higher_version_basedir + '/lib/libgalera_smm.so --datadir='
                            + node.get_data_dir() + ' --basedir=' + higher_version_basedir + ' --log-error=' +
-                           node.get_error_log() + ' >> ' + node.get_error_log() + ' 2>&1 &')
+                           node.get_error_log() + ' >> ' + node.get_error_log() + ' 2>&1')
             utility_cmd.check_testcase(0, "Starting cluster node with upgraded version")
         else:
             startup_cmd = (higher_version_basedir + '/bin/mysqld --defaults-file=' + node.get_conf_file() +
                            ' --datadir=' + node.get_data_dir() + ' --basedir=' + higher_version_basedir +
                            ' --wsrep-provider=none --log-error=' + node.get_error_log() +
-                           ' >> ' + node.get_error_log() + ' 2>&1 &')
+                           ' >> ' + node.get_error_log() + ' 2>&1')
         if debug == 'YES':
             print(startup_cmd)
-        os.system(startup_cmd)
+        launch_result = launch_server(startup_cmd)
+        if launch_result != 0:
+            print("Cluster node" + str(node.get_node_number()) + " startup failed on launch with exit code "
+                  + str(launch_result))
+            utility_cmd.check_testcase(launch_result, "Starting cluster node with upgraded version")
+            return
         utility_cmd.startup_check(node)
         utility_cmd.wait_for_wsrep_status(node, node_sync_timeout)
         if int(version) < int("080000"):
@@ -441,8 +505,7 @@ class StartCluster:
             node.shutdown()
             time.sleep(30)
             utility_cmd.check_testcase(0, "Shutdown cluster node" + str(node.get_node_number()) + " after upgrade run")
-            create_startup = ('sed -i  "s#' + lower_base_dir + '#' + higher_version_basedir + '#g" ' + workdir +
-                              node.get_startup_script())
+            create_startup = ('sed -i  "s#' + lower_base_dir + '#' + higher_version_basedir + '#g" ' + node.get_startup_script())
             if debug == 'YES':
                 print(create_startup)
             os.system(create_startup)
@@ -453,16 +516,12 @@ class StartCluster:
                 os.system(remove_bootstrap_option)
             time.sleep(5)
 
-            upgrade_startup = "bash " + node.get_startup_script()
-            if debug == 'YES':
-                print(upgrade_startup)
-            result = os.system(upgrade_startup)
-            utility_cmd.check_testcase(result,
-                                       "Starting cluster node" + str(node.get_node_number()) + " after upgrade run")
+            utility_cmd.restart_cluster_node(node)
             utility_cmd.startup_check(node)
             utility_cmd.wait_for_wsrep_status(node)
 
-    @staticmethod
+
+    
     def pxb_sanity_check(node: DbConnection, version: str):
         """ This method will check pxb installation and
             cleanup backup directory
@@ -472,6 +531,7 @@ class StartCluster:
             print('\tERROR! Percona Xtrabackup is not installed.')
             exit(1)
 
+        backup_dir = get_backup_dir(node.get_worker_id())
         # Recreate backup directory
         if os.path.exists(backup_dir):
             shutil.rmtree(backup_dir)
@@ -485,22 +545,38 @@ class StartCluster:
             queries = ["create user 'xbuser'@'localhost' identified by 'test'",
                        "grant all on *.* to 'xbuser'@'localhost'"]
         node.execute_queries(queries)
-
+        
     @staticmethod
     def pxb_backup(node: DbConnection, encryption: bool, copy_back_to_ps_node: bool = False, debug: str = 'NO'):
         """ This method will backup PXC/PS data directory
             with the help of xtrabackup.
         """
+        worker_id = node.get_worker_id()
+        workdir = get_workdir(worker_id)
+        backup_dir = get_backup_dir(worker_id)
         # Enable keyring file plugin if it is encryption run
         backup_extra = ''
+        prepare_extra = ''
         if encryption:
             version_info = node.get_mysql_version()
             version = "{:02d}{:02d}{:02d}".format(int(version_info.split('.')[0]),
                                                   int(version_info.split('.')[1]),
-                                                  int(version_info.split('.')[2]))
+                                                  int(version_info.split('.')[2].split('-')[0]))
             if int(version) < int("080024"):
                 backup_extra = " --keyring-file-data=" + node.get_data_dir() + \
                            "/keyring --early-plugin-load='keyring_file=keyring_file.so'"
+            else:
+                prepare_extra = " --component-keyring-config=" + node.get_data_dir() + '/' + comp_name + '.cnf'
+        def run_with_timeout(cmd, description):
+            try:
+                return subprocess.call(cmd, shell=True, timeout=BACKUP_TIMEOUT)
+            except subprocess.TimeoutExpired as timeout_error:
+                print(description + " timed out after " + str(BACKUP_TIMEOUT) + " seconds: "
+                      + str(timeout_error))
+                return -1
+            except Exception as backup_error:
+                print(description + " failed with exception: " + str(backup_error))
+                return -2
 
         # Backup data using xtrabackup
         backup_cmd = ("xtrabackup --user=xbuser --password='test' --backup --target-dir=" + backup_dir +
@@ -508,14 +584,16 @@ class StartCluster:
                       backup_extra + " --lock-ddl >" + workdir + "/log/xb_backup.log 2>&1")
         if debug == 'YES':
             print(backup_cmd)
-        os.system(backup_cmd)
+        result = run_with_timeout(backup_cmd, "xtrabackup backup")
+        Utility.check_testcase(result, "xtrabackup backup")
 
         # Prepare backup for node startup
-        prepare_backup = ("xtrabackup --prepare --target_dir=" + backup_dir + ' ' + backup_extra +
+        prepare_backup = ("xtrabackup --prepare --target_dir=" + backup_dir + ' ' + backup_extra + prepare_extra +
                           " --lock-ddl >" + workdir + "/log/xb_backup_prepare.log 2>&1")
         if debug == 'YES':
             print(prepare_backup)
-        os.system(prepare_backup)
+        result = run_with_timeout(prepare_backup, "xtrabackup prepare")
+        Utility.check_testcase(result, "xtrabackup prepare")
 
         # copy backup directory to destination
         if copy_back_to_ps_node:
@@ -523,16 +601,18 @@ class StartCluster:
             if os.path.exists(dest_datadir):
                 shutil.rmtree(dest_datadir)
             copy_backup = ("xtrabackup --copy-back --target-dir=" + backup_dir + " --datadir=" + dest_datadir +
-                           " " + backup_extra + " --lock-ddl >" + workdir + "/log/copy_backup.log 2>&1")
+                           " " + backup_extra + " --lock-ddl >" +  workdir + "/log/copy_backup.log 2>&1")
             if debug == 'YES':
                 print(copy_backup)
-            os.system(copy_backup)
+            result = run_with_timeout(copy_backup, "xtrabackup copy-back")
+            Utility.check_testcase(result, "xtrabackup copy-back")
 
             # Copy keyring file to destination directory for encryption startup
             if encryption:
                 if int(version) >= int("080024"):
-                    dest_keyring_file = os.path.join(workdir, 'keyring', 'psnode1_' + comp_name)
-                    shutil.copy(component_keyring_file_path(node.get_node_number()), dest_keyring_file)
+                    keyring_dir = get_keyring_dir(worker_id)
+                    dest_keyring_file = os.path.join(keyring_dir, ps_node_keyring_file_name.format(node_number=1))
+                    shutil.copy(os.path.join(keyring_dir, node_keyring_file_name.format(node_number=1)), dest_keyring_file)
                     with open(os.path.join(dest_datadir, comp_name + '.cnf'), 'w') as cnf_file:
                         json.dump({"path": dest_keyring_file, "read_only": False}, cnf_file, indent=2)
                         cnf_file.write('\n')

--- a/util/rqg_datagen.py
+++ b/util/rqg_datagen.py
@@ -1,4 +1,5 @@
 import os
+import subprocess
 import configparser
 from util import utility
 from util.db_connection import DbConnection
@@ -10,6 +11,7 @@ parent_dir = os.path.normpath(os.path.join(script_dir, '../'))
 rand_gen_dir = parent_dir + '/randgen'
 gen_data_pl = rand_gen_dir + '/gendata.pl'
 
+RQG_RUN_TIMEOUT = 60 * 60
 
 class RQGDataGen:
     def __init__(self, node: DbConnection, debug):
@@ -50,7 +52,12 @@ class RQGDataGen:
                               work_dir + "/log/rqg_run.log 2>&1"
                 if self.debug == 'YES':
                     print(rqg_command)
-                result = os.system(rqg_command)
+                try:
+                    result = subprocess.call(rqg_command, shell=True, timeout=RQG_RUN_TIMEOUT)
+                except subprocess.TimeoutExpired:
+                    print("RQG data load (DB: " + db + ") timed out after "
+                          + str(RQG_RUN_TIMEOUT) + " seconds")
+                    result = 1
                 self.utility_cmd.check_testcase(result, "RQG data load (DB: " + db + ")")
 
     def pxc_dataload(self, work_dir):

--- a/util/sysbench_run.py
+++ b/util/sysbench_run.py
@@ -1,6 +1,9 @@
 import os
 import itertools
+import signal
+import subprocess
 import sys
+import time
 from config import *
 from util.db_connection import DbConnection
 
@@ -17,13 +20,18 @@ EXPORT_LUA_PATH = 'export SBTEST_SCRIPTDIR="' + parent_dir + \
 
 lua_dir = parent_dir + "/sysbench_lua/"
 
+# Maximum time (in seconds) a single sysbench run is allowed to take.
+SYSBENCH_RUN_TIMEOUT = 50 * 60
+# Seconds to poll after launching background sysbench before treating launch as successful.
+SYSBENCH_LAUNCH_CHECK_TIMEOUT = 2
+
 
 class SysbenchRun:
-    def __init__(self, node: DbConnection, debug):
+    def __init__(self, node: DbConnection, debug, workdir):
         self.__node = node
         self.__debug = debug
         self.__utility_cmd = utility.Utility(debug)
-        self.__log_dir = WORKDIR + "/log/"
+        self.__log_dir = workdir + "/log/"
 
     def sanity_check(self, db):
         # Sanity check for sysbench run
@@ -73,11 +81,12 @@ class SysbenchRun:
         return self.execute_sysbench_query(query)
 
     def test_sysbench_load(self, db, tables=SYSBENCH_TABLE_COUNT, threads=SYSBENCH_THREADS,
-                           table_size=SYSBENCH_NORMAL_TABLE_SIZE, use_load_table_size: bool = False):
+                           table_size=SYSBENCH_NORMAL_TABLE_SIZE, use_load_table_size: bool = False,
+                           ignore_timeout: bool = False):
         if use_load_table_size:
             table_size = SYSBENCH_LOAD_TEST_TABLE_SIZE
         result = self.sysbench_load(db, tables, threads, table_size)
-        self.__utility_cmd.check_testcase(result, "Sysbench data load with threads " + str(threads))
+        self.__utility_cmd.check_testcase(result, "Sysbench data load with threads " + str(threads), not ignore_timeout)
 
     def sysbench_ts_encryption(self, db, threads):
         # Check InnoDB system tablespace encryption
@@ -201,10 +210,7 @@ class SysbenchRun:
         self.__utility_cmd.check_testcase(result, "Sysbench data cleanup (threads : " + str(threads) + ")")
 
     def sysbench_oltp_read_write(self, db, table_count, threads, table_size, time, background: bool = False, port=None):
-        if background:
-            log_file = "sysbench_read_write_" + str(threads) + ".log & "
-        else:
-            log_file = "sysbench_read_write_" + str(threads) + ".log "
+        log_file = "sysbench_read_write_" + str(threads) + ".log"
 
         if port is not None:
             host_to_connect = " --mysql-host=127.0.0.1 --mysql-port=" + str(port)
@@ -219,7 +225,7 @@ class SysbenchRun:
                  "--mysql-user={user} --mysql-password={password} --db-driver=mysql " + host_to_connect +
                  " --time={time} --db-ps-mode=disable run > {log-file}").format(**params)
 
-        return self.execute_sysbench_query(query)
+        return self.execute_sysbench_query(query, background=background)
 
     def test_sysbench_oltp_read_write(self, db, tables=SYSBENCH_TABLE_COUNT, threads=SYSBENCH_THREADS,
                                       table_size=SYSBENCH_NORMAL_TABLE_SIZE, time=SYSBENCH_RUN_TIME,
@@ -230,10 +236,7 @@ class SysbenchRun:
         self.__utility_cmd.check_testcase(result, "Initiated sysbench oltp run", is_terminate)
 
     def sysbench_oltp_read_only(self, db, table_count, threads, table_size, time, background: bool = False):
-        if background:
-            log_file = "sysbench_read_only.log & "
-        else:
-            log_file = "sysbench_read_only.log "
+        log_file = "sysbench_read_only.log"
 
         params = self.get_params('oltp_read_only.lua', table_size, table_count, threads,
                                  db, log_file)
@@ -244,17 +247,14 @@ class SysbenchRun:
                  "--mysql-user={user} --mysql-password={password} --db-driver=mysql "
                  "--mysql-socket={socket} --time={time} --db-ps-mode=disable run > {log-file}").format(**params)
 
-        return self.execute_sysbench_query(query)
+        return self.execute_sysbench_query(query, background=background)
 
     def test_sysbench_oltp_read_only(self, db, table_count, threads, table_size, time, background=False):
         result = self.sysbench_oltp_read_only(db, table_count, threads, table_size, time, background)
         self.__utility_cmd.check_testcase(result, "Initiated sysbench oltp read only run")
 
     def sysbench_oltp_write_only(self, db, table_count, threads, table_size, time, background: bool = False):
-        if background:
-            log_file = "sysbench_write_only.log &"
-        else:
-            log_file = "sysbench_write_only.log"
+        log_file = "sysbench_write_only.log"
 
         params = self.get_params('oltp_write_only.lua', table_size, table_count, threads,
                                  db, log_file)
@@ -269,7 +269,7 @@ class SysbenchRun:
                  "--mysql-user={user} --mysql-password={password} --db-driver=mysql "
                  "--mysql-socket={socket} --time={time} --db-ps-mode=disable run > {log-file}").format(**params)
 
-        return self.execute_sysbench_query(query)
+        return self.execute_sysbench_query(query, background=background)
 
     def sysbench_custom_table(self, db, table_count, thread, table_size):
         table_format = ['DEFAULT', 'DYNAMIC', 'FIXED', 'COMPRESSED', 'REDUNDANT', 'COMPACT']
@@ -308,10 +308,7 @@ class SysbenchRun:
         utility_cmd.check_testcase(result, "Sysbench data load")
 
     def sysbench_tpcc_run(self, db, table_count, threads, table_size, time, background: bool = False):
-        if background:
-            log_file = "sysbench_write_only.log &"
-        else:
-            log_file = "sysbench_write_only.log"
+        log_file = "sysbench_write_only.log"
 
         params = self.get_params('oltp_write_only.lua', table_size, table_count, threads,
                                  db, log_file)
@@ -326,12 +323,37 @@ class SysbenchRun:
                  "--mysql-user={user} --mysql-password={password} --db-driver=mysql "
                  "--mysql-socket={socket} --time={time} --db-ps-mode=disable run > {log-file}").format(**params)
 
-        return self.execute_sysbench_query(query)
+        return self.execute_sysbench_query(query, background=background)
 
-    def execute_sysbench_query(self, query):
+    def execute_sysbench_query(self, query, background: bool = False):
+        full_cmd = EXPORT_LUA_PATH + "; exec " + query.strip()
         if self.__debug == 'YES':
-            print(query)
-        if int(os.system(EXPORT_LUA_PATH + ";" + query)) != 0:
+            print(full_cmd)
+        process = subprocess.Popen(full_cmd, shell=True, start_new_session=True, stderr=subprocess.STDOUT)
+
+        if background:
+            deadline = time.time() + SYSBENCH_LAUNCH_CHECK_TIMEOUT
+            while time.time() < deadline:
+                returncode = process.poll()
+                if returncode is not None:
+                    if returncode != 0:
+                        print("ERROR!: sysbench failed on launch")
+                        return 1
+                    return 0
+                time.sleep(0.2)
+            return 0
+
+        try:
+            returncode = process.wait(timeout=SYSBENCH_RUN_TIMEOUT)
+        except subprocess.TimeoutExpired:
+            try:
+                os.killpg(os.getpgid(process.pid), signal.SIGKILL)
+            except ProcessLookupError:
+                pass
+            process.wait()
+            print("Timeout! sysbench run timed out after " + str(SYSBENCH_RUN_TIMEOUT / 60) + " minutes")
+            return 1
+        if returncode != 0:
             print("ERROR!: sysbench run is failed")
             return 1
         return 0

--- a/util/utility.py
+++ b/util/utility.py
@@ -1,16 +1,80 @@
 #!/usr/bin/env python3
 import os
+import signal
+import socket
+import subprocess
 import sys
 import time
 from datetime import datetime
 from enum import Enum
+from pathlib import Path
 
 import config
 from util.db_connection import DbConnection
 
 pstress_bin = config.PSTRESS_BIN
 
-DEFAULT_SERVER_UP_TIMEOUT = 300
+DEFAULT_SERVER_UP_TIMEOUT = 600
+# Seconds to poll after launching a background server before treating launch as successful.
+SERVER_LAUNCH_CHECK_TIMEOUT = 2
+
+
+def launch_server(cmd):
+    """Start a long-running server command and verify it did not fail immediately."""
+    stripped_cmd = cmd.strip()
+    if not stripped_cmd.startswith('exec '):
+        cmd = 'exec ' + stripped_cmd
+    process = subprocess.Popen(cmd, shell=True, start_new_session=True, stderr=subprocess.DEVNULL)
+    deadline = time.time() + SERVER_LAUNCH_CHECK_TIMEOUT
+    while time.time() < deadline:
+        returncode = process.poll()
+        if returncode is not None:
+            return returncode
+        time.sleep(0.2)
+    return 0
+
+# Bounded, parallel-safe port allocation.
+# Each worker owns a contiguous band of ports so that parallel workers never
+# overlap, and the values always stay well below the 65535 TCP limit \
+# Layout per worker band (WORKER_PORT_BAND_SIZE wide):
+#   PXC nodes : band_base + (node - 1) * NODE_PORT_STRIDE
+#   PS nodes  : band_base + PS_PORT_SUB_BASE  + (node - 1) * NODE_PORT_STRIDE
+# PXC additionally uses galera/ist/sst ports which fit inside the
+# per-node stride.
+PORT_BAND_BASE = 10000
+WORKER_PORT_BAND_SIZE = 1000
+NODE_PORT_STRIDE = 100
+PS_PORT_SUB_BASE = 600
+
+
+def is_port_busy(port):
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.settimeout(1)
+        return sock.connect_ex(('127.0.0.1', port)) == 0
+
+
+def find_available_ports(start, end, count):
+    """Return count available TCP ports from the inclusive range [start, end].
+
+    Ports are scanned in ascending order. Raises if fewer than count are free.
+    """
+    if count < 1:
+        raise ValueError("count must be at least 1")
+    if start > end:
+        raise ValueError("start must be <= end")
+
+    ports = []
+    for port in range(start, end + 1):
+        if not is_port_busy(port):
+            ports.append(port)
+            if len(ports) == count:
+                return ports
+    raise Exception(
+        f"Found only {len(ports)} available port(s) in range {start}-{end}, needed {count}")
+
+
+def worker_port_band_base(worker_id):
+    return PORT_BAND_BASE + max(worker_id, 0) * WORKER_PORT_BAND_SIZE
 
 
 class RplType(Enum):
@@ -31,14 +95,12 @@ def test_scenario_header(test_scenario_description: str):
     print('------------------------------------------------------------------------------------')
 
 
-def sysbench_pid():
-    query = 'pidof sysbench'
-    return os.popen(query).read().rstrip()
-
-
-def sysbech_node_pid(node_number: int):
-    query = ("ps -ef | grep sysbench | grep -v gep | grep node" + str(node_number) +
-             " | awk '{print $2}'")
+def sysbench_pid(node: DbConnection):
+    worker_id = node.get_worker_id()
+    pattern = "node" + str(node.get_node_number())
+    if worker_id > 0:
+        pattern = "w" + str(worker_id) + "/" + pattern
+    query = ("ps -ef | grep sysbench | grep -v grep | grep " + pattern + " | awk '{print $2}'")
     return os.popen(query).read().rstrip()
 
 
@@ -117,6 +179,9 @@ class Utility:
                                                     "performance_schema.replication_connection_status where "
                                                     "channel_name='" + channel + "'")
         if replica_status not in ['ON', 'Yes']:
+            if int(version) >= int("050700"):
+                status = node.execute_get_values("SELECT * FROM performance_schema.replication_connection_status where channel_name='" + channel + "'")
+                print(status)
             self.check_testcase(1, "Replica IO thread is not running, check replica status")
         else:
             self.check_testcase(0, "Replica IO thread is running fine")
@@ -136,6 +201,9 @@ class Utility:
                                                     "performance_schema.replication_applier_status where "
                                                     "channel_name='" + channel + "'")
         if replica_status not in ['YES', 'ON']:
+            if int(version) >= int("050700"):
+                status = node.execute_get_values("SELECT * FROM performance_schema.replication_applier_status_by_worker where channel_name='" + channel + "'")
+                print(status)
             self.check_testcase(1, "Replica SQL thread is not running, check replica status")
         else:
             self.check_testcase(0, "Replica SQL thread is running fine")
@@ -214,15 +282,18 @@ class Utility:
         if self.debug == 'YES':
             print("Terminating " + process_name + " run : " + kill_cmd)
         result = os.system(kill_cmd)
+        if "sysbench" in process_name and result != 0:
+            result = 0
         if ignore_error:
             result = 0
         self.check_testcase(result, "Killed " + process_name + " run")
         time.sleep(10)
 
     def restart_cluster(self, nodes: list[DbConnection]):
-        os.system("sed -i 's#safe_to_bootstrap: 0#safe_to_bootstrap: 1#' " +
-                  config.WORKDIR + '/node1/grastate.dat')
         for node in nodes:
+            if 'node1' in Path(node.get_data_dir()).parts:
+                os.system("sed -i 's#safe_to_bootstrap: 0#safe_to_bootstrap: 1#' " +
+                          node.get_data_dir() + '/grastate.dat')
             self.restart_and_check_node(node)
 
     def restart_and_check_node(self, node: DbConnection):
@@ -231,10 +302,15 @@ class Utility:
 
     def restart_cluster_node(self, node: DbConnection):
 
-        restart_server = "bash " + node.get_startup_script()
+        startup_script = node.get_startup_script()
         if self.debug == 'YES':
-            print(restart_server)
-        result = os.system(restart_server)
+            print(startup_script)
+        with open(startup_script) as startup_file:
+            startup_cmd = startup_file.read().strip()
+        result = launch_server(startup_cmd)
+        if result != 0:
+            print("Starting/Restarting Cluster Node" + str(node.get_node_number()) +
+                  " failed on launch with exit code " + str(result))
         self.check_testcase(result, "Starting/Restarting Cluster Node" + str(node.get_node_number()))
 
     def startup_check(self, node: DbConnection, terminate_on_startup_failure: bool = True):
@@ -242,22 +318,30 @@ class Utility:
             startup status.
         """
         dbconnection_status = -1
-        for startup_timer in range(DEFAULT_SERVER_UP_TIMEOUT):
+        start_time = time.time()
+        while True:
             time.sleep(1)
             dbconnection_status = int(node.connection_check(False))
             if dbconnection_status == 0:
+                break
+            if time.time() > start_time + DEFAULT_SERVER_UP_TIMEOUT:
+                print("Timeout while starting/restarting cluster node" + str(node.get_node_number()))
                 break
         self.check_testcase(dbconnection_status, "Verify node startup", terminate_on_startup_failure)
         return dbconnection_status
 
     def wait_for_wsrep_status(self, node: DbConnection, node_sync_timeout=DEFAULT_SERVER_UP_TIMEOUT):
         node_synced = -1
-        for startup_timer in range(node_sync_timeout):
+        start_time = time.time()
+        while True:
             time.sleep(1)
             wsrep_status = (node.execute_get_row("show status like 'wsrep_local_state_comment'")[1]
                             .strip())
             if wsrep_status == "Synced":
                 node_synced = 0
+                break
+            if time.time() > start_time + node_sync_timeout:
+                print("Timeout while waiting for cluster node" + str(node.get_node_number()) + " to sync")
                 break
         self.check_testcase(node_synced, "Cluster Node recovery is successful")
 
@@ -267,14 +351,15 @@ class Utility:
         pid = os.popen(query).read().rstrip()
         self.kill_process(pid, "cluster node")
 
-    def kill_cluster_nodes(self):
+    def kill_cluster_nodes(self, nodes: list[DbConnection]):
         if self.debug == 'YES':
             print("Killing existing mysql process using 'kill -9' command")
-        os.system("ps -ef | grep '" + config.WORKDIR + "/conf/node[0-9].cnf' | grep -v grep | "
-                                                       "awk '{print $2}' | xargs kill -9 >/dev/null 2>&1")
+        for node in nodes:
+            self.kill_cluster_node(node)
 
     def pstress_run(self, workdir: str, socket: str, db: str, seed: int, step_num: int = None,
                     tables: int = 25, threads: int = 50, records: int = None, pstress_extra: str = None):
+        timeout = 300
         if not os.path.isfile(pstress_bin):
             print(pstress_bin + ' does not exist')
             exit(1)
@@ -286,10 +371,24 @@ class Utility:
         pstress_cmd = pstress_bin + " --database=" + db + " --threads=" + str(threads) + " --logdir=" + \
                       workdir + "/log --log-all-queries --log-failed-queries --user=root --socket=" + \
                       socket + " --seed " + str(seed) + " --tables " + str(tables) + " " + \
-                      pstress_extra + " --seconds 300 --grammar-file " + \
+                      pstress_extra + " --seconds " + str(timeout) + " --grammar-file " + \
                       config.PSTRESS_GRAMMAR_FILE + extra_setting + " > " + \
                       workdir + "/log/pstress_run.log"
         self.check_testcase(0, "PSTRESS RUN command : " + pstress_cmd)
-        query_status = os.system(pstress_cmd)
-        if int(query_status) != 0:
-            self.check_testcase(1, "ERROR!: PSTRESS run failed")
+        is_terminate : bool = True
+        process = subprocess.Popen(pstress_cmd, shell=True, start_new_session=True)
+        try:
+            query_status = process.wait(timeout=timeout * 2)
+        except subprocess.TimeoutExpired:
+            try:
+                os.killpg(os.getpgid(process.pid), signal.SIGKILL)
+            except ProcessLookupError:
+                pass
+            process.wait()
+            print("Timeout! pstress run timed out after " + str(timeout * 2) + " seconds")
+            query_status = 1
+            is_terminate = False
+        # pstress subsequent runs would have failed queries too.
+        if step_num is not None and step_num > 1:
+            is_terminate = False
+        self.check_testcase(query_status, "PSTRESS run completed", is_terminate)


### PR DESCRIPTION
Modified qa_framework.py to make it possible to run the tests in parallel.
Added new option -w to qa_framework.py to run the tests in parallel.
Updated -t option to accept multiple tests.
Updated -s option to accept multiple suites.
The output of specific tests is now printed to test log files. Whereas the final result pass/fail is printed in the main output log file and console.
Added a way to skip a test from running if it is listed under disabled.list file in script directory which would make it easier to temporarily disable any failing test.
Updated many commands to run with timeout and fail gracefully in case of timeout exceeds which would help in detection of failures in case of server hang or environment issues.
Running the tests will automatically cleanup the directory set in workdir under config.ini file if it already exists before running any tests.
Fixed failing backup_replication.py test in encryption mode.

Test results:

Cmd: python3 qa_framework.py --suite=correctness -e -w 2
################################################################################
Adding tests from correctness suite

Work directory /home/parveez.baig/tests_data already exists, removing it
Creating work directory /home/parveez.baig/tests_data
################################################################################

Test correctness.cluster_interaction.py                          w2 [Pass]
Test correctness.chaosmonkey-test.py                             w2 [Pass]
Test correctness.crash_recovery.py                               w1 [Pass]
Test correctness.consistency_check.py                            w2 [Pass]


Cmd: python3 qa_framework.py --suite=galera_sr,sysbench_run -e -w 2
################################################################################
Adding tests from galera_sr suite
Adding tests from sysbench_run suite

Work directory /home/parveez.baig/tests_data already exists, removing it
Creating work directory /home/parveez.baig/tests_data
################################################################################

Test galera_sr.thread_pool_qa.py                                 w1 [Pass]
Test galera_sr.galera_basic_sr_qa.py                             w2 [Pass]
Test sysbench_run.sysbench_customized_dataload_test.py           w1 [Pass]
Test sysbench_run.sysbench_read_only_test.py                     w2 [Pass]
Test sysbench_run.sysbench_oltp_test.py                          w1 [Pass]`
